### PR TITLE
Update infrastructure_lifeline_mediation_randomized_sim_v0_2.py

### DIFF
--- a/infrastructure_lifeline_mediation_randomized_sim_v0_2.py
+++ b/infrastructure_lifeline_mediation_randomized_sim_v0_2.py
@@ -1,4 +1,4 @@
- #!/usr/bin/env python3
+#!/usr/bin/env python3
 """
 Infrastructure Lifeline Mediation Randomized Simulation v0.2
 


### PR DESCRIPTION
Fixes a leading space before the shebang line.

- Removes the extra leading space before #!/usr/bin/env python3
- Keeps the simulation logic unchanged
- No behavior change