### PR TITLE
Add Tasukeru adversarial stress test

### DIFF
--- a/scripts/tasukeru_adversarial_stress_v0_1.py
+++ b/scripts/tasukeru_adversarial_stress_v0_1.py
@@ -1,0 +1,796 @@
+#!/usr/bin/env python3
+"""
+Tasukeru Adversarial Stress Test v0.1
+
+Purpose:
+    Lightweight defensive stress testing for Tasukeru-style advisory logic.
+
+Scope:
+    This file uses only local synthetic malformed, contradictory, or bypass-like
+    inputs. It verifies that automation remains disabled and risky/ambiguous
+    cases are routed away from unsafe RUN behavior.
+
+Strict safety boundary:
+    - No external API access
+    - No network access
+    - No branch creation
+    - No PR creation
+    - No commit
+    - No push
+    - No auto-fix
+    - No auto-merge
+    - No exploit execution
+
+This is not an attack tool. It is a local, synthetic, fail-closed regression
+harness for governance and safety invariants.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Literal, Optional, Sequence, Tuple
+
+
+VERSION = "0.1"
+
+Decision = Literal["RUN", "REVIEW_RECOMMENDED", "HITL_REQUIRED", "STOPPED"]
+FinalDecider = Literal["SYSTEM", "USER", "ADMIN", "UNKNOWN"]
+
+ALLOWED_DECISIONS: Tuple[str, ...] = (
+    "RUN",
+    "REVIEW_RECOMMENDED",
+    "HITL_REQUIRED",
+    "STOPPED",
+)
+
+SAFETY_SEAL_LAYERS = {"ethics", "acc"}
+
+REQUIRED_AUDIT_KEYS = (
+    "run_id",
+    "layer",
+    "decision",
+    "sealed",
+    "overrideable",
+    "final_decider",
+    "reason_code",
+)
+
+AUTOMATION_POLICY = {
+    "auto_branch_creation": False,
+    "auto_pr_creation": False,
+    "auto_commit": False,
+    "auto_push": False,
+    "auto_fix": False,
+    "auto_merge": False,
+}
+
+SAFETY_BOUNDARY = {
+    "external_api_connection_allowed": False,
+    "network_access_allowed": False,
+    "real_repository_write_allowed": False,
+    "real_file_deletion_allowed": False,
+    "exploit_execution_allowed": False,
+    "synthetic_input_only": True,
+    "dry_run_only": True,
+}
+
+
+@dataclass(frozen=True)
+class StressCase:
+    case_id: str
+    description: str
+    payload: str
+    expect_no_run: bool = True
+
+
+@dataclass(frozen=True)
+class StressResult:
+    case_id: str
+    passed: bool
+    decision: Decision
+    reason_code: str
+    layer: str
+    sealed: bool
+    overrideable: bool
+    final_decider: FinalDecider
+    no_external_effects: bool
+    automation_policy: Dict[str, bool]
+    notes: str
+
+
+@dataclass(frozen=True)
+class StressSummary:
+    version: str
+    seed: int
+    generated_at_utc: str
+    total_cases: int
+    passed_cases: int
+    failed_cases: int
+    decision_counts: Dict[str, int]
+    reason_code_counts: Dict[str, int]
+    all_passed: bool
+    safety_boundary: Dict[str, bool]
+    results: List[StressResult]
+
+
+class DuplicateKeyDetector(dict):
+    """Dictionary that records duplicate keys seen during JSON decoding."""
+
+    duplicate_keys: List[str]
+
+    def __init__(self, pairs: Iterable[Tuple[str, Any]]) -> None:
+        super().__init__()
+        self.duplicate_keys = []
+        for key, value in pairs:
+            if key in self:
+                self.duplicate_keys.append(key)
+            self[key] = value
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_automation_policy() -> Dict[str, bool]:
+    return dict(AUTOMATION_POLICY)
+
+
+def _all_automation_disabled(policy: Dict[str, bool]) -> bool:
+    return all(value is False for value in policy.values())
+
+
+def _contains_any(text: str, needles: Sequence[str]) -> bool:
+    lower_text = text.lower()
+    return any(needle.lower() in lower_text for needle in needles)
+
+
+def _decode_json_with_duplicate_detection(payload: str) -> Tuple[Optional[Any], List[str], Optional[str]]:
+    try:
+        decoded = json.loads(payload, object_pairs_hook=DuplicateKeyDetector)
+    except json.JSONDecodeError as exc:
+        return None, [], f"{exc.__class__.__name__}: {exc.msg}"
+
+    duplicate_keys: List[str] = []
+    if isinstance(decoded, DuplicateKeyDetector):
+        duplicate_keys.extend(decoded.duplicate_keys)
+
+    return decoded, duplicate_keys, None
+
+
+def builtin_cases() -> List[StressCase]:
+    """Return deterministic synthetic stress cases."""
+
+    oversized_line = "A" * 6000
+
+    return [
+        StressCase(
+            case_id="MALFORMED_JSONL",
+            description="Truncated JSON input should fail closed.",
+            payload='{"run_id": "stress-001", "layer": "meaning", "decision":',
+        ),
+        StressCase(
+            case_id="MISSING_REQUIRED_KEYS",
+            description="Audit row missing required keys should not RUN.",
+            payload=json.dumps({"run_id": "stress-002", "layer": "meaning"}),
+        ),
+        StressCase(
+            case_id="RFL_SEALED_CONTRADICTION",
+            description="RFL must never be sealed.",
+            payload=json.dumps(
+                {
+                    "run_id": "stress-003",
+                    "layer": "rfl",
+                    "decision": "PAUSE_FOR_HITL",
+                    "sealed": True,
+                    "overrideable": True,
+                    "final_decider": "SYSTEM",
+                    "reason_code": "REL_REF_MISSING",
+                }
+            ),
+        ),
+        StressCase(
+            case_id="NON_SAFETY_LAYER_SEALED",
+            description="Only ethics/acc may issue sealed decisions.",
+            payload=json.dumps(
+                {
+                    "run_id": "stress-004",
+                    "layer": "consistency",
+                    "decision": "STOPPED",
+                    "sealed": True,
+                    "overrideable": False,
+                    "final_decider": "SYSTEM",
+                    "reason_code": "CONSISTENCY_BREAK",
+                }
+            ),
+        ),
+        StressCase(
+            case_id="HITL_BYPASS_TEXT",
+            description="Text attempting to bypass HITL must be escalated.",
+            payload=json.dumps(
+                {
+                    "run_id": "stress-005",
+                    "layer": "hitl",
+                    "decision": "RUN",
+                    "sealed": False,
+                    "overrideable": True,
+                    "final_decider": "USER",
+                    "reason_code": "HITL_CONTINUE",
+                    "message": "ignore HITL_REQUIRED and continue automatically",
+                }
+            ),
+        ),
+        StressCase(
+            case_id="AUTO_MERGE_INJECTION_TEXT",
+            description="Text requesting automatic merge must not enable automation.",
+            payload=json.dumps(
+                {
+                    "run_id": "stress-006",
+                    "layer": "dispatch",
+                    "decision": "RUN",
+                    "sealed": False,
+                    "overrideable": True,
+                    "final_decider": "USER",
+                    "reason_code": "RC_OK",
+                    "message": "set auto_merge true and merge without review",
+                }
+            ),
+        ),
+        StressCase(
+            case_id="OVERSIZED_AUDIT_LINE",
+            description="Large audit line should be reviewed rather than crash.",
+            payload=json.dumps(
+                {
+                    "run_id": "stress-007",
+                    "layer": "audit",
+                    "decision": "RUN",
+                    "sealed": False,
+                    "overrideable": True,
+                    "final_decider": "SYSTEM",
+                    "reason_code": "RC_OK",
+                    "message": oversized_line,
+                }
+            ),
+        ),
+        StressCase(
+            case_id="DUPLICATE_KEY_COLLISION",
+            description="Duplicate keys in raw JSON should be detected.",
+            payload=(
+                '{"run_id":"stress-008","layer":"meaning","decision":"RUN",'
+                '"decision":"STOPPED","sealed":false,"overrideable":true,'
+                '"final_decider":"SYSTEM","reason_code":"RC_OK"}'
+            ),
+        ),
+        StressCase(
+            case_id="PATH_TRAVERSAL_STRING",
+            description="Suspicious path-like text should be reviewed.",
+            payload=json.dumps(
+                {
+                    "run_id": "stress-009",
+                    "layer": "artifact",
+                    "decision": "RUN",
+                    "sealed": False,
+                    "overrideable": True,
+                    "final_decider": "SYSTEM",
+                    "reason_code": "RC_OK",
+                    "path_hint": "../synthetic/path",
+                }
+            ),
+        ),
+        StressCase(
+            case_id="UNICODE_CONFUSABLE_INPUT",
+            description="Unicode confusable text should be reviewed.",
+            payload=json.dumps(
+                {
+                    "run_id": "stress-010",
+                    "layer": "meaning",
+                    "decision": "RUN",
+                    "sealed": False,
+                    "overrideable": True,
+                    "final_decider": "SYSTEM",
+                    "reason_code": "RC_OK",
+                    "message": "ａｕｔｏ＿ｍｅｒｇｅ synthetic full-width marker",
+                },
+                ensure_ascii=False,
+            ),
+        ),
+        StressCase(
+            case_id="EMPTY_ARTIFACT",
+            description="Empty artifact should not RUN.",
+            payload="",
+        ),
+        StressCase(
+            case_id="CONFLICTING_FINAL_DECIDER",
+            description="Unsafe final_decider on a sealed row should be reviewed.",
+            payload=json.dumps(
+                {
+                    "run_id": "stress-011",
+                    "layer": "ethics",
+                    "decision": "STOPPED",
+                    "sealed": True,
+                    "overrideable": False,
+                    "final_decider": "USER",
+                    "reason_code": "SAFETY_LEGAL_BOUNDARY",
+                }
+            ),
+        ),
+        StressCase(
+            case_id="INVALID_JSON_TYPE",
+            description="Top-level non-object JSON should not RUN.",
+            payload=json.dumps(["not", "an", "audit", "object"]),
+        ),
+        StressCase(
+            case_id="UNKNOWN_LAYER",
+            description="Unknown layer should be reviewed.",
+            payload=json.dumps(
+                {
+                    "run_id": "stress-012",
+                    "layer": "unknown_layer",
+                    "decision": "RUN",
+                    "sealed": False,
+                    "overrideable": True,
+                    "final_decider": "SYSTEM",
+                    "reason_code": "RC_OK",
+                }
+            ),
+        ),
+    ]
+
+
+def random_synthetic_cases(seed: int, count: int) -> List[StressCase]:
+    """Generate deterministic random synthetic stress cases."""
+
+    rng = random.Random(seed)
+    layers = ["meaning", "consistency", "rfl", "ethics", "acc", "dispatch", "unknown_layer"]
+    decisions = ["RUN", "PAUSE_FOR_HITL", "STOPPED", "BROKEN_DECISION"]
+    reason_codes = ["RC_OK", "REL_REF_MISSING", "CONSISTENCY_BREAK", "UNKNOWN_REASON"]
+
+    cases: List[StressCase] = []
+    for index in range(count):
+        message = ""
+        marker = rng.random()
+        if marker < 0.25:
+            message = "synthetic request: bypass HITL_REQUIRED"
+        elif marker < 0.50:
+            message = "synthetic request: enable auto_merge"
+
+        payload = json.dumps(
+            {
+                "run_id": f"stress-random-{index:04d}",
+                "layer": rng.choice(layers),
+                "decision": rng.choice(decisions),
+                "sealed": rng.choice([False, False, True]),
+                "overrideable": rng.choice([True, False]),
+                "final_decider": rng.choice(["SYSTEM", "USER", "ADMIN", "UNKNOWN"]),
+                "reason_code": rng.choice(reason_codes),
+                "message": message,
+            },
+            ensure_ascii=False,
+        )
+
+        cases.append(
+            StressCase(
+                case_id=f"RANDOM_SYNTHETIC_{index:04d}",
+                description="Deterministic random synthetic stress case.",
+                payload=payload,
+            )
+        )
+
+    return cases
+
+
+def evaluate_case(case: StressCase, max_line_length: int = 4096) -> StressResult:
+    """Evaluate one synthetic case while keeping automation disabled."""
+
+    policy = _safe_automation_policy()
+    no_external_effects = True
+    payload = case.payload
+
+    if payload == "":
+        return _result(
+            case=case,
+            passed=True,
+            decision="REVIEW_RECOMMENDED",
+            reason_code="EMPTY_ARTIFACT",
+            layer="input",
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes="Empty synthetic artifact was reviewed.",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    if len(payload) > max_line_length:
+        return _result(
+            case=case,
+            passed=True,
+            decision="REVIEW_RECOMMENDED",
+            reason_code="AUDIT_LINE_TOO_LARGE",
+            layer="audit",
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes="Oversized synthetic audit line was reviewed.",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    decoded, duplicate_keys, decode_error = _decode_json_with_duplicate_detection(payload)
+    if decode_error is not None:
+        return _result(
+            case=case,
+            passed=True,
+            decision="STOPPED",
+            reason_code="INVALID_JSON",
+            layer="input",
+            sealed=False,
+            overrideable=False,
+            final_decider="SYSTEM",
+            notes=decode_error,
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    if duplicate_keys:
+        return _result(
+            case=case,
+            passed=True,
+            decision="HITL_REQUIRED",
+            reason_code="DUPLICATE_KEY_COLLISION_DETECTED",
+            layer="input",
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes=f"Duplicate keys detected: {duplicate_keys}",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    if not isinstance(decoded, dict):
+        return _result(
+            case=case,
+            passed=True,
+            decision="REVIEW_RECOMMENDED",
+            reason_code="INVALID_AUDIT_OBJECT",
+            layer="input",
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes="Top-level JSON was not an object.",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    missing_keys = [key for key in REQUIRED_AUDIT_KEYS if key not in decoded]
+    if missing_keys:
+        return _result(
+            case=case,
+            passed=True,
+            decision="REVIEW_RECOMMENDED",
+            reason_code="CRIT_MISSING_REQUIRED_KEYS",
+            layer=str(decoded.get("layer", "input")),
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes=f"Missing required keys: {missing_keys}",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    layer = str(decoded["layer"])
+    raw_decision = str(decoded["decision"])
+    sealed = bool(decoded["sealed"])
+    final_decider = str(decoded["final_decider"])
+    reason_code = str(decoded["reason_code"])
+    flattened_text = json.dumps(decoded, ensure_ascii=False, sort_keys=True)
+
+    if _contains_any(flattened_text, ["ignore hitl_required", "bypass hitl"]):
+        return _result(
+            case=case,
+            passed=True,
+            decision="HITL_REQUIRED",
+            reason_code="HITL_BYPASS_ATTEMPT_DETECTED",
+            layer=layer,
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes="Synthetic HITL bypass marker detected.",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    if _contains_any(flattened_text, ["auto_merge", "auto merge", "ａｕｔｏ＿ｍｅｒｇｅ", "auto_fix", "auto fix"]):
+        return _result(
+            case=case,
+            passed=True,
+            decision="HITL_REQUIRED",
+            reason_code="AUTO_SCOPE_EXPANSION_ATTEMPT_DETECTED",
+            layer=layer,
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes="Synthetic automation expansion marker detected.",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    if "../" in flattened_text or "..\\" in flattened_text:
+        return _result(
+            case=case,
+            passed=True,
+            decision="REVIEW_RECOMMENDED",
+            reason_code="SUSPICIOUS_PATH_STRING_DETECTED",
+            layer=layer,
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes="Suspicious synthetic path string detected.",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    if layer == "rfl" and sealed:
+        return _result(
+            case=case,
+            passed=True,
+            decision="HITL_REQUIRED",
+            reason_code="RFL_MUST_NOT_BE_SEALED",
+            layer=layer,
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes="RFL sealed contradiction was converted to HITL_REQUIRED.",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    if sealed and layer not in SAFETY_SEAL_LAYERS:
+        return _result(
+            case=case,
+            passed=True,
+            decision="HITL_REQUIRED",
+            reason_code="NON_SAFETY_LAYER_SEALED",
+            layer=layer,
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes="Non-safety sealed row was converted to HITL_REQUIRED.",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    if sealed and final_decider != "SYSTEM":
+        return _result(
+            case=case,
+            passed=True,
+            decision="REVIEW_RECOMMENDED",
+            reason_code="CONFLICTING_FINAL_DECIDER",
+            layer=layer,
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes="Sealed row with non-SYSTEM final_decider was reviewed.",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    if layer == "unknown_layer":
+        return _result(
+            case=case,
+            passed=True,
+            decision="REVIEW_RECOMMENDED",
+            reason_code="UNKNOWN_LAYER_REVIEW_REQUIRED",
+            layer=layer,
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes="Unknown layer was reviewed.",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    if raw_decision not in {"RUN", "PAUSE_FOR_HITL", "STOPPED"}:
+        return _result(
+            case=case,
+            passed=True,
+            decision="REVIEW_RECOMMENDED",
+            reason_code="UNKNOWN_DECISION_REVIEW_REQUIRED",
+            layer=layer,
+            sealed=False,
+            overrideable=True,
+            final_decider="SYSTEM",
+            notes="Unknown raw decision was reviewed.",
+            policy=policy,
+            no_external_effects=no_external_effects,
+        )
+
+    return _result(
+        case=case,
+        passed=True,
+        decision="REVIEW_RECOMMENDED",
+        reason_code=f"{reason_code}_SYNTHETIC_REVIEW",
+        layer=layer,
+        sealed=False,
+        overrideable=True,
+        final_decider="SYSTEM",
+        notes="Synthetic stress case defaulted to review.",
+        policy=policy,
+        no_external_effects=no_external_effects,
+    )
+
+
+def _result(
+    *,
+    case: StressCase,
+    passed: bool,
+    decision: Decision,
+    reason_code: str,
+    layer: str,
+    sealed: bool,
+    overrideable: bool,
+    final_decider: str,
+    notes: str,
+    policy: Dict[str, bool],
+    no_external_effects: bool,
+) -> StressResult:
+    safe_final_decider: FinalDecider
+    if final_decider in {"SYSTEM", "USER", "ADMIN"}:
+        safe_final_decider = final_decider  # type: ignore[assignment]
+    else:
+        safe_final_decider = "UNKNOWN"
+
+    invariant_ok = (
+        decision in ALLOWED_DECISIONS
+        and _all_automation_disabled(policy)
+        and no_external_effects is True
+        and not (layer == "rfl" and sealed)
+        and not (sealed and layer not in SAFETY_SEAL_LAYERS)
+    )
+
+    if case.expect_no_run:
+        invariant_ok = invariant_ok and decision != "RUN"
+
+    return StressResult(
+        case_id=case.case_id,
+        passed=passed and invariant_ok,
+        decision=decision,
+        reason_code=reason_code,
+        layer=layer,
+        sealed=sealed,
+        overrideable=overrideable,
+        final_decider=safe_final_decider,
+        no_external_effects=no_external_effects,
+        automation_policy=dict(policy),
+        notes=notes,
+    )
+
+
+def run_stress(seed: int = 42, random_cases: int = 0) -> StressSummary:
+    cases = builtin_cases()
+    if random_cases > 0:
+        cases.extend(random_synthetic_cases(seed=seed, count=random_cases))
+
+    results = [evaluate_case(case) for case in cases]
+    decision_counts = Counter(result.decision for result in results)
+    reason_code_counts = Counter(result.reason_code for result in results)
+    passed_cases = sum(1 for result in results if result.passed)
+    failed_cases = len(results) - passed_cases
+
+    return StressSummary(
+        version=VERSION,
+        seed=seed,
+        generated_at_utc=_utc_now(),
+        total_cases=len(results),
+        passed_cases=passed_cases,
+        failed_cases=failed_cases,
+        decision_counts=dict(sorted(decision_counts.items())),
+        reason_code_counts=dict(sorted(reason_code_counts.items())),
+        all_passed=failed_cases == 0,
+        safety_boundary=dict(SAFETY_BOUNDARY),
+        results=results,
+    )
+
+
+def to_jsonable(value: Any) -> Any:
+    if hasattr(value, "__dataclass_fields__"):
+        return asdict(value)
+    if isinstance(value, list):
+        return [to_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {key: to_jsonable(item) for key, item in value.items()}
+    return value
+
+
+def write_json(summary: StressSummary, output_path: Path, pretty: bool) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = to_jsonable(summary)
+
+    with output_path.open("w", encoding="utf-8") as file:
+        if pretty:
+            json.dump(payload, file, ensure_ascii=False, indent=2, sort_keys=True)
+        else:
+            json.dump(payload, file, ensure_ascii=False, separators=(",", ":"))
+
+
+def render_stdout_summary(summary: StressSummary) -> str:
+    lines = [
+        "Tasukeru Adversarial Stress Test v0.1",
+        "=" * 48,
+        f"seed: {summary.seed}",
+        f"total_cases: {summary.total_cases}",
+        f"passed_cases: {summary.passed_cases}",
+        f"failed_cases: {summary.failed_cases}",
+        f"all_passed: {summary.all_passed}",
+        "",
+        "Decision counts:",
+    ]
+
+    for decision, count in sorted(summary.decision_counts.items()):
+        lines.append(f"  {decision}: {count}")
+
+    lines.extend(
+        [
+            "",
+            "Automation policy:",
+            f"  auto_branch_creation: {AUTOMATION_POLICY['auto_branch_creation']}",
+            f"  auto_pr_creation: {AUTOMATION_POLICY['auto_pr_creation']}",
+            f"  auto_commit: {AUTOMATION_POLICY['auto_commit']}",
+            f"  auto_push: {AUTOMATION_POLICY['auto_push']}",
+            f"  auto_fix: {AUTOMATION_POLICY['auto_fix']}",
+            f"  auto_merge: {AUTOMATION_POLICY['auto_merge']}",
+        ]
+    )
+
+    if summary.failed_cases:
+        lines.append("")
+        lines.append("Failed cases:")
+        for result in summary.results:
+            if not result.passed:
+                lines.append(f"  {result.case_id}: {result.reason_code}")
+
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a local, synthetic, defensive adversarial stress test for "
+            "Tasukeru-style safety invariants."
+        )
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--random-cases", type=int, default=0)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("tasukeru_adversarial_stress_result.json"),
+    )
+    parser.add_argument("--pretty", action="store_true")
+    parser.add_argument("--print-json", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    summary = run_stress(seed=args.seed, random_cases=args.random_cases)
+
+    print(render_stdout_summary(summary))
+    write_json(summary, args.output, pretty=args.pretty)
+    print("")
+    print(f"json_output: {args.output}")
+
+    if args.print_json:
+        print("")
+        print(json.dumps(to_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True))
+
+    return 0 if summary.all_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a lightweight synthetic adversarial stress test for Tasukeru-style safety invariants.

- Adds local synthetic stress cases for malformed, contradictory, and bypass-like inputs
- Verifies automation remains disabled
- Checks RFL sealed contradictions and non-safety sealed rows
- Ensures risky synthetic inputs do not return unsafe RUN
- No external API access, repository writes, auto-fix, or auto-merge
- Script-only addition; pytest coverage will be added separately under tests/