### PR TITLE
Add dimension dependency report and verification

### DIFF
--- a/.github/workflows/tasukeru-analysis.yml
+++ b/.github/workflows/tasukeru-analysis.yml
@@ -261,6 +261,9 @@ jobs:
           three_d_vaf_json_path = Path("tasukeru_3d_vulnerability_review.json")
           sis_md_path = Path("tasukeru_safety_impact_simulation.md")
           sis_json_path = Path("tasukeru_safety_impact_simulation.json")
+          dimension_dependency_md_path = Path("tasukeru_dimension_dependency_report.md")
+          dimension_dependency_json_path = Path("tasukeru_dimension_dependency_report.json")
+          dimension_dependency_verify_path = Path("tasukeru_dimension_dependency_verify.json")
 
           AUTO_FALSE = {
               "auto_branch_allowed": False,
@@ -4680,13 +4683,17 @@ jobs:
               summary_counts = parse_summary_decision_counts(summary_text)
               three_d_vaf_payload = read_json(three_d_vaf_json_path, {})
               sis_payload = read_json(sis_json_path, {})
+              dimension_dependency_payload = read_json(dimension_dependency_json_path, {})
+              dimension_dependency_verify_payload = read_json(dimension_dependency_verify_path, {})
               pr_comment_text = read_text(pr_comment_path, "")
 
-              # 3D-VAF / SIS / PR-comment consistency.
+              # 3D-VAF / SIS / 3D-DAC / PR-comment consistency.
               three_d_metadata = metadata.get("three_d_vaf", {}) if isinstance(metadata, dict) else {}
               sis_metadata = metadata.get("safety_impact_simulation", {}) if isinstance(metadata, dict) else {}
+              dimension_dependency_metadata = metadata.get("dimension_dependency", {}) if isinstance(metadata, dict) else {}
               three_d_counts = three_d_vaf_payload.get("counts", {}) if isinstance(three_d_vaf_payload, dict) else {}
               sis_counts = sis_payload.get("counts", {}) if isinstance(sis_payload, dict) else {}
+              dimension_dependency_counts = dimension_dependency_payload.get("counts", {}) if isinstance(dimension_dependency_payload, dict) else {}
               sis_comment_policy = sis_payload.get("comment_policy", {}) if isinstance(sis_payload, dict) else {}
               sis_overall_risk_level = str(sis_payload.get("overall_risk_level", "UNKNOWN")) if isinstance(sis_payload, dict) else "UNKNOWN"
 
@@ -4745,6 +4752,38 @@ jobs:
                   output_value=int(sis_metadata.get("hitl_required", -1)),
                   artifact=str(sis_json_path),
                   reason_code="RESULT_SIS_METADATA_HITL_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="3d_dac.entry_count",
+                  process_value=len(entries),
+                  output_value=int(dimension_dependency_counts.get("entry_count", -1)),
+                  artifact=str(dimension_dependency_json_path),
+                  reason_code="RESULT_3D_DAC_ENTRY_COUNT_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="3d_dac.metadata_dependency_mismatch_count",
+                  process_value=int(dimension_dependency_counts.get("dependency_mismatch_count", -1)),
+                  output_value=int(dimension_dependency_metadata.get("dependency_mismatch_count", -1)),
+                  artifact=str(dimension_dependency_json_path),
+                  reason_code="RESULT_3D_DAC_METADATA_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="3d_dac.verify_verified",
+                  process_value=bool(dimension_dependency_payload.get("verified", False)),
+                  output_value=bool(dimension_dependency_verify_payload.get("verified", False)),
+                  artifact=str(dimension_dependency_verify_path),
+                  reason_code="RESULT_3D_DAC_VERIFY_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="3d_dac.verify_decision",
+                  process_value=str(dimension_dependency_payload.get("decision", "UNKNOWN")),
+                  output_value=str(dimension_dependency_verify_payload.get("decision", "UNKNOWN")),
+                  artifact=str(dimension_dependency_verify_path),
+                  reason_code="RESULT_3D_DAC_DECISION_MISMATCH",
               )
 
               # Public-comment consistency is intentionally coarse: the comment must
@@ -5068,6 +5107,9 @@ jobs:
                       str(three_d_vaf_json_path),
                       str(sis_md_path),
                       str(sis_json_path),
+                      str(dimension_dependency_md_path),
+                      str(dimension_dependency_json_path),
+                      str(dimension_dependency_verify_path),
                       str(pr_comment_path),
                   ],
                   "process_counts": normalized_counts,
@@ -5851,6 +5893,270 @@ jobs:
                       f.write(f"\n... and {len(sis_entries) - 80} more entries in `tasukeru_safety_impact_simulation.json`.\n")
               return payload
 
+          def build_dimension_dependency_entry(
+              entry: dict[str, Any],
+              vaf_entry: dict[str, Any] | None,
+              sis_entry: dict[str, Any] | None,
+          ) -> dict[str, Any]:
+              """Audit dependency consistency across finding, 3D axes, SIS, classification, and output.
+
+              3D-DAC is read-only. It does not mutate findings, change decisions,
+              apply fixes, create PRs, push commits, or merge changes.
+              """
+              decision = str(entry.get("decision", entry.get("level", "")))
+              file_path = str(entry.get("file", ""))
+              reason_code = str(entry.get("reason_code", ""))
+              fingerprint_hash = str(entry.get("fingerprint_hash", ""))
+              path_profile = str(entry.get("path_profile", classify_path_profile(file_path)))
+
+              dependency_checks: list[dict[str, Any]] = []
+
+              def add_check(name: str, ok: bool, detail: str, *, severity: str = "REVIEW") -> None:
+                  dependency_checks.append(
+                      {
+                          "name": name,
+                          "ok": bool(ok),
+                          "severity": severity,
+                          "detail": detail,
+                      }
+                  )
+
+              add_check(
+                  "finding_reference",
+                  bool(fingerprint_hash and file_path and file_path != "?" and reason_code),
+                  "finding must retain fingerprint, file, and reason_code references",
+              )
+              add_check(
+                  "vaf_reference",
+                  isinstance(vaf_entry, dict) and bool(vaf_entry.get("fingerprint_hash")),
+                  "3D-VAF entry must be linked by fingerprint_hash",
+              )
+              add_check(
+                  "sis_reference",
+                  isinstance(sis_entry, dict) and bool(sis_entry.get("fingerprint_hash")),
+                  "SIS entry must be linked by fingerprint_hash",
+              )
+
+              if isinstance(vaf_entry, dict):
+                  add_check(
+                      "vaf_decision_dependency",
+                      str(vaf_entry.get("decision", "")) == decision,
+                      "3D-VAF decision must match source finding decision",
+                  )
+                  add_check(
+                      "vaf_structure_dependency",
+                      str(vaf_entry.get("file", "")) == file_path,
+                      "3D-VAF affected file must match source finding file",
+                  )
+                  structure_axis = vaf_entry.get("structure_axis", {}) if isinstance(vaf_entry.get("structure_axis"), dict) else {}
+                  impact_axis = vaf_entry.get("impact_axis", {}) if isinstance(vaf_entry.get("impact_axis"), dict) else {}
+                  add_check(
+                      "structure_axis_dependency",
+                      str(structure_axis.get("path_profile", "")) == path_profile,
+                      "structure axis path_profile must follow source finding path_profile",
+                  )
+                  fallback_required = bool(vaf_entry.get("fallback_required"))
+                  rollback_cost = str(impact_axis.get("rollback_cost", ""))
+                  add_check(
+                      "impact_fallback_dependency",
+                      (not fallback_required) or rollback_cost == "review_required",
+                      "fallback_required should be reflected in impact-axis rollback_cost",
+                  )
+
+              if isinstance(sis_entry, dict):
+                  add_check(
+                      "sis_decision_dependency",
+                      str(sis_entry.get("decision", "")) == decision,
+                      "SIS decision must match source finding decision",
+                  )
+                  add_check(
+                      "sis_reason_dependency",
+                      str(sis_entry.get("reason_code", "")) == reason_code,
+                      "SIS reason_code must match source finding reason_code",
+                  )
+                  risk_level = str(sis_entry.get("risk_level", "NONE"))
+                  add_check(
+                      "classification_impact_dependency",
+                      not (decision == "HITL_REQUIRED" and risk_level in {"NONE", "LOW"}),
+                      "HITL_REQUIRED findings should not be classified as NONE/LOW safety impact",
+                      severity="PAUSE_FOR_HITL",
+                  )
+                  visibility = sis_entry.get("visibility", {}) if isinstance(sis_entry.get("visibility"), dict) else {}
+                  add_check(
+                      "public_output_dependency",
+                      visibility.get("include_exploit_steps_in_public_comment") is False
+                      and visibility.get("include_payloads_in_public_comment") is False
+                      and visibility.get("include_attack_paths_in_public_comment") is False,
+                      "public output must not include exploit steps, payloads, or attack paths",
+                      severity="PAUSE_FOR_HITL",
+                  )
+
+              failed_checks = [item for item in dependency_checks if not item.get("ok")]
+              review_required = bool(failed_checks)
+              review_severity = "PAUSE_FOR_HITL" if any(item.get("severity") == "PAUSE_FOR_HITL" for item in failed_checks) else "REVIEW"
+
+              return {
+                  "fingerprint_hash": entry.get("fingerprint_hash"),
+                  "source": entry.get("source"),
+                  "decision": decision,
+                  "reason_code": reason_code,
+                  "file": file_path,
+                  "line": entry.get("line"),
+                  "path_profile": path_profile,
+                  "review_required": review_required,
+                  "review_severity": review_severity if review_required else "NONE",
+                  "dependency_mismatch_count": len(failed_checks),
+                  "failed_checks": failed_checks,
+                  "dependency_checks": dependency_checks,
+                  "checked_dimensions": [
+                      "finding",
+                      "structure",
+                      "impact",
+                      "classification",
+                      "output",
+                  ],
+              }
+
+          def generate_tasukeru_dimension_dependency_audit(
+              entries: list[dict[str, Any]],
+              three_d_vaf_payload: dict[str, Any],
+              sis_payload: dict[str, Any],
+              state: dict[str, Any],
+              metadata: dict[str, Any],
+          ) -> dict[str, Any]:
+              """Generate 3D-DAC artifacts for read-only dependency consistency audit."""
+              vaf_entries = three_d_vaf_payload.get("entries", []) if isinstance(three_d_vaf_payload, dict) else []
+              sis_entries = sis_payload.get("entries", []) if isinstance(sis_payload, dict) else []
+              vaf_by_fingerprint = {
+                  str(item.get("fingerprint_hash")): item
+                  for item in vaf_entries
+                  if isinstance(item, dict) and item.get("fingerprint_hash")
+              }
+              sis_by_fingerprint = {
+                  str(item.get("fingerprint_hash")): item
+                  for item in sis_entries
+                  if isinstance(item, dict) and item.get("fingerprint_hash")
+              }
+
+              dependency_entries = [
+                  build_dimension_dependency_entry(
+                      entry,
+                      vaf_by_fingerprint.get(str(entry.get("fingerprint_hash"))),
+                      sis_by_fingerprint.get(str(entry.get("fingerprint_hash"))),
+                  )
+                  for entry in entries
+              ]
+              dependency_mismatch_count = sum(int(item.get("dependency_mismatch_count", 0) or 0) for item in dependency_entries)
+              review_required_count = sum(1 for item in dependency_entries if item.get("review_required"))
+              pause_for_hitl_count = sum(1 for item in dependency_entries if item.get("review_severity") == "PAUSE_FOR_HITL")
+              verified = dependency_mismatch_count == 0
+              decision = "RUN" if verified else "PAUSE_FOR_HITL"
+
+              payload = {
+                  "schema_version": "3d-dac-v0.1",
+                  "tool": "tasukeru_dimension_dependency_audit",
+                  "purpose": (
+                      "Check dependency consistency across findings, 3D-VAF structure/impact axes, "
+                      "SIS risk metadata, classification, and public-output policy."
+                  ),
+                  "verified": verified,
+                  "decision": decision,
+                  "reason_code": "DIMENSION_DEPENDENCY_VERIFIED" if verified else "DIMENSION_DEPENDENCY_REVIEW_REQUIRED",
+                  "counts": {
+                      "entry_count": len(dependency_entries),
+                      "dependency_mismatch_count": dependency_mismatch_count,
+                      "review_required_count": review_required_count,
+                      "pause_for_hitl_count": pause_for_hitl_count,
+                  },
+                  "checked_dimensions": [
+                      "finding",
+                      "structure",
+                      "impact",
+                      "classification",
+                      "output",
+                  ],
+                  "policy": {
+                      "advisory_only": True,
+                      "report_only": True,
+                      "mutates_findings": False,
+                      "changes_existing_decisions": False,
+                      "auto_branch_allowed": False,
+                      "auto_pr_creation_allowed": False,
+                      "auto_commit_allowed": False,
+                      "auto_push_allowed": False,
+                      "autofix_allowed": False,
+                      "auto_merge_allowed": False,
+                      "include_exploit_payloads": False,
+                      "include_attack_steps": False,
+                      "external_scanning_allowed": False,
+                  },
+                  "entries": dependency_entries,
+              }
+              payload["report_sha256"] = canonical_hash(
+                  {
+                      "schema_version": payload["schema_version"],
+                      "verified": payload["verified"],
+                      "decision": payload["decision"],
+                      "reason_code": payload["reason_code"],
+                      "counts": payload["counts"],
+                  }
+              )
+              write_json(dimension_dependency_json_path, payload)
+
+              verify_payload = {
+                  "schema_version": "3d-dac-verify-v0.1",
+                  "verified": verified,
+                  "decision": decision,
+                  "reason_code": payload["reason_code"],
+                  "dependency_mismatch_count": dependency_mismatch_count,
+                  "review_required_count": review_required_count,
+                  "report_artifact": str(dimension_dependency_json_path),
+                  "summary_artifact": str(dimension_dependency_md_path),
+                  "report_sha256": payload.get("report_sha256"),
+                  "auto_apply_allowed": False,
+                  "human_decision_required_on_mismatch": True,
+              }
+              write_json(dimension_dependency_verify_path, verify_payload)
+
+              with dimension_dependency_md_path.open("w", encoding="utf-8") as f:
+                  f.write("# Tasukeru 3D Dimension Dependency Audit\n\n")
+                  f.write("This report is advisory-only and read-only. It checks dependency consistency across 3D review axes, SIS, classification, and output policy.\n\n")
+                  f.write("## Result\n\n")
+                  f.write(f"- Verified: `{verified}`\n")
+                  f.write(f"- Decision: `{decision}`\n")
+                  f.write(f"- Reason code: `{payload['reason_code']}`\n")
+                  f.write(f"- Entries: `{len(dependency_entries)}`\n")
+                  f.write(f"- Dependency mismatches: `{dependency_mismatch_count}`\n")
+                  f.write(f"- Review required: `{review_required_count}`\n")
+                  f.write(f"- PAUSE_FOR_HITL candidates: `{pause_for_hitl_count}`\n")
+                  f.write(f"- Report hash: `{payload.get('report_sha256')}`\n\n")
+                  f.write("## Policy\n\n")
+                  f.write("- Report-only: `true`\n")
+                  f.write("- Mutates findings: `false`\n")
+                  f.write("- Changes existing decisions: `false`\n")
+                  f.write("- Auto fix: `false`\n")
+                  f.write("- Auto merge: `false`\n")
+                  f.write("- External scanning: `false`\n")
+                  f.write("- Exploit payloads / attack steps: `false`\n\n")
+                  f.write("## Review sample\n\n")
+                  sample = [item for item in dependency_entries if item.get("review_required")][:80]
+                  if not sample:
+                      f.write("- No dependency mismatches detected.\n")
+                  else:
+                      for item in sample:
+                          f.write(
+                              f"- `{item.get('review_severity')}` `{item.get('reason_code')}` "
+                              f"mismatches=`{item.get('dependency_mismatch_count')}` `{item.get('file')}`"
+                          )
+                          if item.get("line"):
+                              f.write(f":{item.get('line')}")
+                          f.write("\n")
+                          for failed in item.get("failed_checks", [])[:5]:
+                              f.write(f"  - `{failed.get('name')}`: {failed.get('detail')}\n")
+                      if len(sample) > 80:
+                          f.write(f"\n... and {len(sample) - 80} more review-required entries in `tasukeru_dimension_dependency_report.json`.\n")
+              return payload
+
           def write_outputs(entries: list[dict[str, Any]], state: dict[str, Any], metadata: dict[str, Any]) -> None:
               counts = Counter(entry["decision"] for entry in entries)
               path_profile_counts = Counter(str(entry.get("path_profile", "unknown")) for entry in entries)
@@ -6104,6 +6410,26 @@ jobs:
               ],
           }
 
+          dimension_dependency_result = generate_tasukeru_dimension_dependency_audit(
+              all_entries,
+              three_d_vaf_result,
+              sis_result,
+              notification_state,
+              metadata,
+          )
+          metadata["dimension_dependency"] = {
+              "schema_version": dimension_dependency_result.get("schema_version"),
+              "verified": dimension_dependency_result.get("verified"),
+              "decision": dimension_dependency_result.get("decision"),
+              "dependency_mismatch_count": dimension_dependency_result.get("counts", {}).get("dependency_mismatch_count"),
+              "review_required_count": dimension_dependency_result.get("counts", {}).get("review_required_count"),
+              "artifacts": [
+                  "tasukeru_dimension_dependency_report.md",
+                  "tasukeru_dimension_dependency_report.json",
+                  "tasukeru_dimension_dependency_verify.json",
+              ],
+          }
+
           finding_validation_result = generate_tasukeru_finding_validation_report(
               all_entries,
               notification_state,
@@ -6246,6 +6572,13 @@ jobs:
           print(f"SIS overall risk level: {sis.get('overall_risk_level')}")
           print(f"SIS risk counts: {sis.get('risk_counts')}")
           print("")
+          print("3D Dimension Dependency Audit v0.1")
+          dimension_dependency = metadata.get("dimension_dependency", {})
+          print(f"3D-DAC verified: {dimension_dependency.get('verified')}")
+          print(f"3D-DAC decision: {dimension_dependency.get('decision')}")
+          print(f"3D-DAC dependency mismatches: {dimension_dependency.get('dependency_mismatch_count')}")
+          print(f"3D-DAC review required: {dimension_dependency.get('review_required_count')}")
+          print("")
           print("Result Consistency Auditor v1")
           result_consistency = metadata.get("result_consistency", {})
           print(f"Result consistency verified: {result_consistency.get('verified')}")
@@ -6285,6 +6618,9 @@ jobs:
             tasukeru_3d_vulnerability_review.json
             tasukeru_safety_impact_simulation.md
             tasukeru_safety_impact_simulation.json
+            tasukeru_dimension_dependency_report.md
+            tasukeru_dimension_dependency_report.json
+            tasukeru_dimension_dependency_verify.json
             tasukeru_self_definition_effective.json
             tasukeru_self_definition_chain.jsonl
             tasukeru_self_definition_verify.json
@@ -6548,6 +6884,9 @@ jobs:
                 "tasukeru_safety_impact_simulation.json",
                 "tasukeru_3d_vulnerability_review.md",
                 "tasukeru_3d_vulnerability_review.json",
+                "tasukeru_dimension_dependency_report.md",
+                "tasukeru_dimension_dependency_report.json",
+                "tasukeru_dimension_dependency_verify.json",
                 "tasukeru_hitl_review.md",
                 "tasukeru_hitl_review.json",
                 "tasukeru_result_consistency_report.md",


### PR DESCRIPTION
Adds 3D-DAC dimension dependency audit outputs to Tasukeru Analysis.

- Adds dimension dependency report, JSON, and verify artifacts
- Checks dependency, impact, classification, and log consistency
- Keeps existing decisions unchanged
- Keeps public PR comments minimal
- Does not add automatic fixes, pushes, or merges