### PR TITLE
Update README to clarify simulator lines description

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 Maestro Orchestrator is a research-oriented orchestration framework for multi-agent governance, fail-closed control, HITL escalation, checkpoint-based resume, and tamper-evident simulation workflows.
 
-This repository contains multiple simulator lines. Some files focus on KAGE-like gate behavior and mediator separation, while others focus on document-task batch execution, checkpointing, audit integrity, and artifact verification.
+This repository contains multiple simulator lines. Some files focus on like gate behavior and mediator separation, while others focus on document-task batch execution, checkpointing, audit integrity, and artifact verification.
 
 ## Beginner reading guide
 


### PR DESCRIPTION
Removed 'KAGE-' prefix from description of simulator lines.