### PR TITLE
Tighten office mediation simulation verification

### DIFF
--- a/agent_office_task_mediation_tasukeru_maestro_sim_v0_5_0.py
+++ b/agent_office_task_mediation_tasukeru_maestro_sim_v0_5_0.py
@@ -169,6 +169,8 @@ class AuditLog:
                 violations.append(f"RFL_MUST_NOT_BE_SEALED:{index}")
             if row.sealed and row.overrideable:
                 violations.append(f"SEALED_MUST_NOT_BE_OVERRIDEABLE:{index}")
+            if row.sealed and row.final_decider != "SYSTEM":
+                violations.append(f"SEALED_FINAL_DECIDER_MUST_BE_SYSTEM:{index}")
             if row.decision == "PAUSE_FOR_HITL" and row.sealed:
                 violations.append(f"PAUSE_FOR_HITL_MUST_NOT_BE_SEALED:{index}")
             prev = row.row_hash
@@ -189,6 +191,14 @@ def stable_hash(obj: Any) -> str:
 
 def write_json(path: Path, obj: Any) -> None:
     path.write_text(json.dumps(obj, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def first_not_none(*values: Any) -> Any:
+    """Return the first value that is not None. Keeps 0 as a valid value."""
+    for value in values:
+        if value is not None:
+            return value
+    return None
 
 
 def threshold_decision(score: float) -> str:
@@ -485,7 +495,10 @@ def mediator_reconcile(
     confidential_signal = any(finding["finding"].startswith("CONFIDENTIAL_") for finding in tasukeru_report["findings"])
 
     profits = {
-        artifact_type: packet["numeric_claims"].get("chart_profit") or packet["numeric_claims"].get("profit")
+        artifact_type: first_not_none(
+            packet["numeric_claims"].get("chart_profit"),
+            packet["numeric_claims"].get("profit"),
+        )
         for artifact_type, packet in by_type.items()
     }
     risk_labels = {artifact_type: packet["risk_label"] for artifact_type, packet in by_type.items()}
@@ -602,6 +615,9 @@ def pel_predict(mediation: dict[str, Any], out_dir: Path) -> dict[str, Any]:
     pel = {
         "schema_version": "pel-office-future-failure-v0.5.0",
         "prediction_is_fact": False,
+        "score_source": "collision_score_plus_safety_buffer",
+        "base_collision_score": mediation["collision_score"],
+        "safety_buffer": 0.04,
         "future_failure_probability": probability,
         "threshold": THRESHOLD,
         "decision": decision,
@@ -654,7 +670,10 @@ def create_revision_proposals(
             packet = by_type.get(artifact_type)
             if not packet:
                 continue
-            current_profit = packet["numeric_claims"].get("chart_profit") or packet["numeric_claims"].get("profit")
+            current_profit = first_not_none(
+                packet["numeric_claims"].get("chart_profit"),
+                packet["numeric_claims"].get("profit"),
+            )
             if current_profit != excel_profit:
                 proposals.append(
                     {
@@ -759,9 +778,9 @@ def maestro_handle_handoff(
                     decision="STOPPED",
                     sealed=True,
                     overrideable=False,
-                    final_decider="SYSTEM_AFTER_USER_AUTH",
+                    final_decider="SYSTEM",
                     reason_code="USER_AUTHORIZED_SEAL",
-                    message="User authorized seal.",
+                    message="User authorized seal; system applied non-overrideable seal.",
                     agent_id=agent_id,
                 )
         return {
@@ -860,6 +879,7 @@ def verify_result(
     *,
     original_task_snapshot: dict[str, Any],
     selected_agents: list[str],
+    tasukeru_report: dict[str, Any],
     mediator_request_verify: dict[str, Any],
     mediation: dict[str, Any],
     pel: dict[str, Any],
@@ -870,6 +890,18 @@ def verify_result(
 
     if set(selected_agents) - set(OFFICE_AGENT_IDS):
         mismatches.append("UNKNOWN_SELECTED_AGENT")
+
+    required_artifacts = set(original_task_snapshot.get("required_artifacts", []))
+    masked_packets = tasukeru_report.get("masked_metadata_packets", [])
+    produced_artifacts = {
+        packet.get("artifact_type")
+        for packet in masked_packets
+        if isinstance(packet, dict) and packet.get("artifact_type")
+    }
+    missing_artifacts = sorted(required_artifacts - produced_artifacts)
+    if missing_artifacts:
+        mismatches.append("REQUIRED_ARTIFACTS_MISSING:" + ",".join(missing_artifacts))
+
     if not original_task_snapshot.get("original_user_task_snapshot_hash"):
         mismatches.append("ORIGINAL_TASK_HASH_MISSING")
     if not mediator_request_verify["verified"]:
@@ -915,6 +947,7 @@ def run_simulation(
     scenario: str,
     selected_agents_value: str,
     human_action_mode: str,
+    save_raw_logs_simulation_only: bool = False,
 ) -> dict[str, Any]:
     rng = random.Random(seed)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -939,7 +972,8 @@ def run_simulation(
 
     artifacts = create_artifacts(scenario, selected_agents)
     raw_agent_logs = make_raw_agent_logs(artifacts)
-    write_json(out_dir / "internal_raw_agent_logs_simulation_only.json", raw_agent_logs)
+    if save_raw_logs_simulation_only:
+        write_json(out_dir / "internal_raw_agent_logs_simulation_only.json", raw_agent_logs)
 
     tasukeru_report = tasukeru_analyze_logs(
         run_id=run_id,
@@ -987,6 +1021,7 @@ def run_simulation(
     rcv = verify_result(
         original_task_snapshot=original_task_snapshot,
         selected_agents=selected_agents,
+        tasukeru_report=tasukeru_report,
         mediator_request_verify=request_verify,
         mediation=mediation,
         pel=pel,
@@ -1006,6 +1041,7 @@ def run_simulation(
             "real_office_generation": False,
             "raw_log_handoff_to_mediator": False,
             "masked_metadata_packet_only": True,
+            "raw_log_artifact_saved": save_raw_logs_simulation_only,
             "external_communication": False,
             "real_process_control": False,
             "auto_apply_revision": False,
@@ -1079,6 +1115,11 @@ def main() -> int:
         default="all",
         help="Comma-separated user-selected agent IDs, or 'all'. Maestro does not select agents autonomously.",
     )
+    parser.add_argument(
+        "--save-raw-logs-simulation-only",
+        action="store_true",
+        help="Save internal raw agent logs for local simulation debugging only. Disabled by default.",
+    )
     parser.add_argument("--human-action", choices=["random", *ACTIONS], default="random")
     args = parser.parse_args()
 
@@ -1088,6 +1129,7 @@ def main() -> int:
         scenario=args.scenario,
         selected_agents_value=args.selected_agents,
         human_action_mode=args.human_action,
+        save_raw_logs_simulation_only=args.save_raw_logs_simulation_only,
     )
 
     mediation = result["mediator_reconciliation"]

--- a/tests/test_agent_office_task_mediation_tasukeru_maestro_sim_v0_5_0.py
+++ b/tests/test_agent_office_task_mediation_tasukeru_maestro_sim_v0_5_0.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -28,7 +29,11 @@ def load_module() -> Any:
     return module
 
 
-def assert_common(result: dict[str, Any]) -> None:
+def assert_common(
+    result: dict[str, Any],
+    *,
+    expect_rcv_verified: bool = True,
+) -> None:
     assert result["schema_version"] == "office-task-mediation-tasukeru-maestro-sim-v0.5.0"
     assert result["safety_boundary"]["local_only"] is True
     assert result["safety_boundary"]["raw_log_handoff_to_mediator"] is False
@@ -50,8 +55,30 @@ def assert_common(result: dict[str, Any]) -> None:
     assert result["mediator_reconciliation"]["raw_log_used"] is False
     assert result["maestro_result"]["maestro_self_decision"] is False
     assert result["arl_verify"]["verified"] is True
-    assert result["result_consistency_verify"]["verified"] is True
-    assert result["result_consistency_verify"]["mismatch_count"] == 0
+    assert result["result_consistency_verify"]["verified"] is expect_rcv_verified
+
+    if expect_rcv_verified:
+        assert result["result_consistency_verify"]["mismatch_count"] == 0
+    else:
+        assert result["result_consistency_verify"]["mismatch_count"] > 0
+
+
+def read_arl_rows(out_dir: Path) -> list[dict[str, Any]]:
+    arl_path = out_dir / "tasukeru_arl.jsonl"
+    assert arl_path.exists()
+    return [
+        json.loads(line)
+        for line in arl_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_first_not_none_preserves_zero() -> None:
+    module = load_module()
+
+    assert module.first_not_none(0, 1) == 0
+    assert module.first_not_none(None, 0, 1) == 0
+    assert module.first_not_none(None, None) is None
 
 
 def test_safe_scenario_does_not_trigger_hitl(tmp_path: Path) -> None:
@@ -74,6 +101,9 @@ def test_safe_scenario_does_not_trigger_hitl(tmp_path: Path) -> None:
     assert mediation["differences"] == []
     assert pel["future_failure_probability"] == 0.04
     assert pel["decision"] == "INFO_ONLY"
+    assert pel["score_source"] == "collision_score_plus_safety_buffer"
+    assert pel["base_collision_score"] == 0.0
+    assert pel["safety_buffer"] == 0.04
     assert maestro["hitl_triggered"] is False
     assert maestro["human_action"] is None
     assert result["final_decision"] == "DRAFT_REVIEW"
@@ -99,6 +129,9 @@ def test_exact_threshold_is_warning_only_and_no_hitl(tmp_path: Path) -> None:
     assert pel["future_failure_probability"] == 0.8
     assert pel["decision"] == "DRAFT_REVIEW"
     assert pel["hitl_required"] is False
+    assert pel["score_source"] == "collision_score_plus_safety_buffer"
+    assert pel["base_collision_score"] == 0.8
+    assert pel["safety_buffer"] == 0.04
     assert maestro["hitl_triggered"] is False
     assert maestro["human_action"] is None
     assert result["final_decision"] == "DRAFT_REVIEW"
@@ -124,6 +157,8 @@ def test_mismatch_with_user_targeted_revision_prompt_creates_drafts_only(tmp_pat
     assert mediation["decision"] == "PAUSE_FOR_HITL"
     assert pel["future_failure_probability"] > 0.8
     assert pel["decision"] == "PAUSE_FOR_HITL"
+    assert pel["score_source"] == "collision_score_plus_safety_buffer"
+    assert pel["safety_buffer"] == 0.04
     assert maestro["hitl_triggered"] is True
     assert maestro["human_action"] == "USER_TARGETED_REVISION_PROMPT"
     assert result["final_decision"] == "DRAFT_REVIEW"
@@ -163,10 +198,29 @@ def test_pii_is_masked_and_stop_is_user_decided(tmp_path: Path) -> None:
     assert any(item["finding"] == "PII_DETECTED_IN_ARTIFACT_TEXT" for item in findings)
     assert any("[MASKED_PII]" in preview for preview in previews)
     assert not any("taro@example.com" in preview for preview in previews)
+    assert not (tmp_path / "internal_raw_agent_logs_simulation_only.json").exists()
     assert result["mediator_reconciliation"]["collision_score"] == 1.0
     assert result["maestro_result"]["hitl_triggered"] is True
     assert result["maestro_result"]["human_action"] == "STOP"
     assert result["final_decision"] == "STOPPED"
+
+
+def test_raw_log_output_is_opt_in_for_local_debugging(tmp_path: Path) -> None:
+    module = load_module()
+    result = module.run_simulation(
+        seed=42,
+        out_dir=tmp_path,
+        scenario="pii",
+        selected_agents_value="all",
+        human_action_mode="STOP",
+        save_raw_logs_simulation_only=True,
+    )
+    assert_common(result)
+
+    raw_log_path = tmp_path / "internal_raw_agent_logs_simulation_only.json"
+    assert raw_log_path.exists()
+    raw_logs = json.loads(raw_log_path.read_text(encoding="utf-8"))
+    assert any("taro@example.com" in item.get("raw_text", "") for item in raw_logs)
 
 
 def test_confidential_signal_is_masked_and_stop_is_user_decided(tmp_path: Path) -> None:
@@ -187,13 +241,14 @@ def test_confidential_signal_is_masked_and_stop_is_user_decided(tmp_path: Path) 
     assert any(item["finding"] == "CONFIDENTIAL_SIGNAL_DETECTED_IN_ARTIFACT_TEXT" for item in findings)
     assert any("[MASKED_SECRET]" in preview for preview in previews)
     assert not any("sk-EXAMPLESECRET12345" in preview for preview in previews)
+    assert not (tmp_path / "internal_raw_agent_logs_simulation_only.json").exists()
     assert result["mediator_reconciliation"]["collision_score"] == 1.0
     assert result["maestro_result"]["hitl_triggered"] is True
     assert result["maestro_result"]["human_action"] == "STOP"
     assert result["final_decision"] == "STOPPED"
 
 
-def test_user_selected_agents_are_respected_before_dispatch(tmp_path: Path) -> None:
+def test_user_selected_agents_are_respected_and_missing_required_artifacts_are_detected(tmp_path: Path) -> None:
     module = load_module()
     result = module.run_simulation(
         seed=42,
@@ -202,13 +257,19 @@ def test_user_selected_agents_are_respected_before_dispatch(tmp_path: Path) -> N
         selected_agents_value="word_agent,excel_agent",
         human_action_mode="NO_ACTION",
     )
-    assert_common(result)
+    assert_common(result, expect_rcv_verified=False)
 
     assert result["selected_agents"] == ["word_agent", "excel_agent"]
     assert {artifact["agent_id"] for artifact in result["artifacts"]} == {"word_agent", "excel_agent"}
+    assert {artifact["artifact_type"] for artifact in result["artifacts"]} == {"word", "excel"}
     assert result["mediator_reconciliation"]["collision_score"] == 0.8
     assert result["mediator_reconciliation"]["decision"] == "DRAFT_REVIEW"
     assert result["maestro_result"]["hitl_triggered"] is False
+
+    rcv = result["result_consistency_verify"]
+    assert rcv["decision"] == "PAUSE_FOR_HITL"
+    assert any(item.startswith("REQUIRED_ARTIFACTS_MISSING:") for item in rcv["mismatches"])
+    assert "powerpoint" in ",".join(rcv["mismatches"])
 
 
 def test_authorize_seal_requires_user_action(tmp_path: Path) -> None:
@@ -229,3 +290,11 @@ def test_authorize_seal_requires_user_action(tmp_path: Path) -> None:
     assert statuses["word_agent"] == "SEALED"
     assert statuses["excel_agent"] == "SEALED"
     assert statuses["powerpoint_agent"] == "SEALED"
+
+    sealed_rows = [row for row in read_arl_rows(tmp_path) if row.get("sealed") is True]
+    assert sealed_rows
+    assert all(row["layer"] == "acc_gate" for row in sealed_rows)
+    assert all(row["decision"] == "STOPPED" for row in sealed_rows)
+    assert all(row["overrideable"] is False for row in sealed_rows)
+    assert all(row["final_decider"] == "SYSTEM" for row in sealed_rows)
+    assert all(row["reason_code"] == "USER_AUTHORIZED_SEAL" for row in sealed_rows)


### PR DESCRIPTION
Add required artifact completeness checks, make profit retrieval None-safe, preserve sealed ARL semantics, document the PEL safety buffer, and make raw simulation log output opt-in.