### PR TITLE
Document intentional E402 suppression in stress test

### DIFF
--- a/tests/test_tasukeru_adversarial_stress_v0_1.py
+++ b/tests/test_tasukeru_adversarial_stress_v0_1.py
@@ -10,7 +10,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-import scripts.tasukeru_adversarial_stress_v0_1 as stress
+# Import after adding the repository root so the local scripts package resolves in test execution.
+import scripts.tasukeru_adversarial_stress_v0_1 as stress  # noqa: E402
 
 
 def _summary_without_timestamp(summary: stress.StressSummary) -> dict[str, Any]:


### PR DESCRIPTION
Document the intentional delayed import in the Tasukeru adversarial stress test.

* Keep the repository-root sys.path setup before importing the local scripts module
* Add an explanatory comment for the delayed import
* Suppress Ruff E402 only on the intentional import line
* Do not change test behavior