### PR TITLE
Fix Office v0.5.0 threshold fail-closed behavior

### DIFF
--- a/agent_office_task_mediation_tasukeru_maestro_sim_v0_5_0.py
+++ b/agent_office_task_mediation_tasukeru_maestro_sim_v0_5_0.py
@@ -202,13 +202,19 @@ def first_not_none(*values: Any) -> Any:
 
 
 def threshold_decision(score: float) -> str:
-    """0.8 exactly is warning/draft only; only > 0.8 triggers HITL."""
-    score = round(float(score), 6)
-    if score > THRESHOLD:
+    """Fail closed for invalid/non-finite scores; only exact 0.8 is draft-only."""
+    try:
+        score_value = float(score)
+    except (TypeError, ValueError):
         return "PAUSE_FOR_HITL"
-    if math.isclose(score, THRESHOLD, rel_tol=0.0, abs_tol=1e-9):
+
+    if not math.isfinite(score_value):
+        return "PAUSE_FOR_HITL"
+    if score_value > THRESHOLD:
+        return "PAUSE_FOR_HITL"
+    if score_value == THRESHOLD:
         return "DRAFT_REVIEW"
-    if score >= 0.4:
+    if score_value >= 0.4:
         return "REVIEW_RECOMMENDED"
     return "INFO_ONLY"
 

--- a/tests/test_agent_office_task_mediation_tasukeru_maestro_sim_v0_5_0.py
+++ b/tests/test_agent_office_task_mediation_tasukeru_maestro_sim_v0_5_0.py
@@ -298,3 +298,18 @@ def test_authorize_seal_requires_user_action(tmp_path: Path) -> None:
     assert all(row["overrideable"] is False for row in sealed_rows)
     assert all(row["final_decider"] == "SYSTEM" for row in sealed_rows)
     assert all(row["reason_code"] == "USER_AUTHORIZED_SEAL" for row in sealed_rows)
+
+def test_threshold_decision_is_fail_closed_at_boundary() -> None:
+    module = load_module()
+    cases = [
+        (0.8, "DRAFT_REVIEW"),
+        (0.8000001, "PAUSE_FOR_HITL"),
+        (float("nan"), "PAUSE_FOR_HITL"),
+        (float("inf"), "PAUSE_FOR_HITL"),
+        (float("-inf"), "PAUSE_FOR_HITL"),
+        ("bad-score", "PAUSE_FOR_HITL"),
+    ]
+
+    for score, expected in cases:
+        assert module.threshold_decision(score) == expected
+


### PR DESCRIPTION
Title:
Fix Office v0.5.0 threshold fail-closed behavior

Description:

## Summary

Fix the threshold decision boundary handling in the Office v0.5.0 simulation and add regression tests.

## Changes

* Remove rounding before threshold comparison in `threshold_decision()`.
* Treat non-finite and invalid score values as `PAUSE_FOR_HITL`.
* Preserve the existing contract that an exact score of `0.8` remains `DRAFT_REVIEW`.
* Add regression tests for threshold-boundary and invalid-score cases.

## Expected behavior

* `0.8` → `DRAFT_REVIEW`
* `0.8000001` → `PAUSE_FOR_HITL`
* `NaN` / `+inf` / `-inf` → `PAUSE_FOR_HITL`
* invalid score text → `PAUSE_FOR_HITL`

## Safety boundary

This change only strengthens decision handling and regression coverage. It does not add external communication, automatic fixes, commits, pushes, merges, or other external actions.
