### PR TITLE
Harden v1.2.3 audit logging and validation gates

### DIFF
--- a/ai_doc_orchestrator_kage3_v1_2_3.py
+++ b/ai_doc_orchestrator_kage3_v1_2_3.py
@@ -242,11 +242,27 @@ _KIND_TOKENS: Dict[KIND, List[str]] = {
 }
 
 
+def _is_ascii_alnum_token(token: str) -> bool:
+    return bool(re.fullmatch(r"[A-Za-z0-9]+", token or ""))
+
+
+def _prompt_has_kind_token(prompt_lower: str, token: str) -> bool:
+    token_lower = (token or "").lower()
+    if not token_lower:
+        return False
+    if _is_ascii_alnum_token(token_lower):
+        return re.search(
+            rf"(?<![A-Za-z0-9]){re.escape(token_lower)}(?![A-Za-z0-9])",
+            prompt_lower,
+        ) is not None
+    return token_lower in prompt_lower
+
+
 def _prompt_mentions_any_kind(prompt: str) -> bool:
     p = (prompt or "").lower()
     for toks in _KIND_TOKENS.values():
         for t in toks:
-            if t.lower() in p:
+            if _prompt_has_kind_token(p, t):
                 return True
     return False
 
@@ -260,7 +276,7 @@ def _meaning_gate(prompt: str, kind: KIND) -> Tuple[Decision, Optional[Layer], s
         return "RUN", None, "MEANING_GENERIC_ALLOW_ALL"
 
     tokens = _KIND_TOKENS[kind]
-    if any(t.lower() in pl for t in tokens):
+    if any(_prompt_has_kind_token(pl, t) for t in tokens):
         return "RUN", None, "MEANING_KIND_MATCH"
 
     return "HITL", "meaning", "MEANING_KIND_MISSING"
@@ -273,21 +289,33 @@ def _validate_contract(kind: KIND, draft: Dict[str, Any]) -> Tuple[bool, str]:
     if kind == "excel":
         cols = draft.get("columns")
         rows = draft.get("rows")
-        if not (isinstance(cols, list) and all(isinstance(x, str) for x in cols)):
+        if not (
+            isinstance(cols, list)
+            and len(cols) > 0
+            and all(isinstance(x, str) for x in cols)
+            and len(set(cols)) == len(cols)
+        ):
             return False, "CONTRACT_EXCEL_COLUMNS_INVALID"
-        if not (isinstance(rows, list) and all(isinstance(x, dict) for x in rows)):
+        if not (isinstance(rows, list) and len(rows) > 0 and all(isinstance(x, dict) for x in rows)):
             return False, "CONTRACT_EXCEL_ROWS_INVALID"
+        expected_keys = set(cols)
+        allowed_value_types = (str, int, float, bool, type(None))
+        for row in rows:
+            if set(row.keys()) != expected_keys:
+                return False, "CONTRACT_EXCEL_ROWS_INVALID"
+            if not all(isinstance(value, allowed_value_types) for value in row.values()):
+                return False, "CONTRACT_EXCEL_ROWS_INVALID"
         return True, "CONTRACT_OK"
 
     if kind == "word":
         heads = draft.get("headings")
-        if not (isinstance(heads, list) and all(isinstance(x, str) for x in heads)):
+        if not (isinstance(heads, list) and len(heads) > 0 and all(isinstance(x, str) for x in heads)):
             return False, "CONTRACT_WORD_HEADINGS_INVALID"
         return True, "CONTRACT_OK"
 
     if kind == "ppt":
         slides = draft.get("slides")
-        if not (isinstance(slides, list) and all(isinstance(x, str) for x in slides)):
+        if not (isinstance(slides, list) and len(slides) > 0 and all(isinstance(x, str) for x in slides)):
             return False, "CONTRACT_PPT_SLIDES_INVALID"
         return True, "CONTRACT_OK"
 
@@ -362,9 +390,23 @@ def _artifact_ext(kind: KIND) -> str:
     return "txt"
 
 
+def _safe_filename_part(value: str) -> str:
+    """
+    Convert an untrusted identifier into a single safe filename segment.
+    """
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", value or "")
+    safe = safe.strip("._")
+    return safe or "artifact"
+
+
 def _write_artifact(artifact_dir: Path, task_id: str, kind: KIND, safe_text: str) -> Path:
     artifact_dir.mkdir(parents=True, exist_ok=True)
-    path = artifact_dir / f"{task_id}.{_artifact_ext(kind)}.txt"
+    resolved_dir = artifact_dir.resolve()
+    safe_task_id = _safe_filename_part(task_id)
+    path = artifact_dir / f"{safe_task_id}.{_artifact_ext(kind)}.txt"
+    resolved_path = path.resolve()
+    if not resolved_path.is_relative_to(resolved_dir):
+        raise ValueError("artifact path escaped artifact_dir")
     path.write_text(redact_sensitive(safe_text), encoding="utf-8")
     return path
 
@@ -459,6 +501,45 @@ def run_simulation(
             }
         )
 
+        # Ethics uses raw_text ONLY in memory and runs before consistency,
+        # so PII leaks cannot be hidden by a contract failure.
+        pii_hit, e_code = _ethics_detect_pii(raw_text)
+        e_dec: Decision = "STOP" if pii_hit else "RUN"
+
+        audit.emit(
+            {
+                "run_id": run_id,
+                "task_id": task_id,
+                "event": "GATE_ETHICS",
+                "layer": "ethics",
+                "decision": e_dec,
+                "reason_code": e_code,
+            }
+        )
+
+        if pii_hit:
+            audit.emit(
+                {
+                    "run_id": run_id,
+                    "task_id": task_id,
+                    "event": "ARTIFACT_SKIPPED",
+                    "layer": "ethics",
+                    "decision": "STOP",
+                    "reason_code": e_code,
+                }
+            )
+            task_results.append(
+                TaskResult(
+                    task_id=task_id,
+                    kind=kind,
+                    decision="STOP",
+                    blocked_layer="ethics",
+                    reason_code=e_code,
+                    artifact_path=None,
+                )
+            )
+            continue
+
         ok, c_code = _validate_contract(kind, draft)
         c_dec: Decision = "RUN" if ok else "HITL"
 
@@ -512,42 +593,6 @@ def run_simulation(
                     decision="HITL",
                     blocked_layer="consistency",
                     reason_code=c_code,
-                    artifact_path=None,
-                )
-            )
-            continue
-
-        pii_hit, e_code = _ethics_detect_pii(raw_text)
-        e_dec: Decision = "STOP" if pii_hit else "RUN"
-
-        audit.emit(
-            {
-                "run_id": run_id,
-                "task_id": task_id,
-                "event": "GATE_ETHICS",
-                "layer": "ethics",
-                "decision": e_dec,
-                "reason_code": e_code,
-            }
-        )
-
-        if pii_hit:
-            audit.emit(
-                {
-                    "run_id": run_id,
-                    "task_id": task_id,
-                    "event": "ARTIFACT_SKIPPED",
-                    "layer": "ethics",
-                    "reason_code": e_code,
-                }
-            )
-            task_results.append(
-                TaskResult(
-                    task_id=task_id,
-                    kind=kind,
-                    decision="STOP",
-                    blocked_layer="ethics",
-                    reason_code=e_code,
                     artifact_path=None,
                 )
             )


### PR DESCRIPTION
Replace ai_doc_orchestrator_kage3_v1_2_3.py with the verified audit-hardened implementation.

Validation:
- SHA256: A8AAC31896715894203E8C5A6652F33015E37066573DCEE62D820DE9DA314CAC
- compile: PASS
- targeted/full validation: 19 pass / 0 fail / 0 error / findings 0
- repo pytest: 176 collected, 1 skipped, remaining passed
- 10000 random stress: PASS, seed 732451

No README, SECURITY, shim, or v1.2.4 changes.