### PR TITLE
Add v1.2.4 strict tests

### DIFF
--- a/tests/test_ai_doc_orchestrator_kage3_v1_2_4.py
+++ b/tests/test_ai_doc_orchestrator_kage3_v1_2_4.py
@@ -689,3 +689,482 @@ def test_consistency_mismatch_continue_enters_regen_pending_and_skips_artifact(
         out.decision in ("PAUSE_FOR_HITL", "STOPPED"),
         f"Unexpected overall decision: {out.decision!r}",
     )
+
+
+def _assert_no_email_like_persisted(root: Path) -> None:
+    """Scan all generated text artifacts/logs under root for raw email-like strings."""
+    if not root.exists():
+        return
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        data = path.read_text(encoding="utf-8", errors="replace")
+        _require(
+            sim.EMAIL_RE.search(data) is None,
+            f"raw email-like string leaked into {path}",
+        )
+        _require(
+            "raw_text" not in data,
+            f"raw_text marker leaked into {path}",
+        )
+
+
+def _events_for_task(rows: list[dict[str, Any]], task_id: str) -> list[dict[str, Any]]:
+    return [row for row in rows if row.get("task_id") == task_id]
+
+
+def _event_index(events: list[dict[str, Any]], event: str) -> int:
+    for i, row in enumerate(events):
+        if row.get("event") == event:
+            return i
+    _fail(f"event not found: {event}")
+    return -1
+
+
+def test_meaning_gate_rejects_alphanumeric_substring_false_positives() -> None:
+    """
+    English/alphanumeric kind tokens must not match as substrings.
+    These were previous regression examples.
+    """
+    prompt = "documentary wordplay tableau slideware"
+    for kind in ("word", "excel", "ppt"):
+        decision, layer, reason = sim._meaning_gate(prompt, kind)
+        _require_equal(
+            decision,
+            "RUN",
+            f"Expected generic RUN for substring-only prompt kind={kind}",
+        )
+        _require_equal(layer, None, f"Expected no blocked layer for kind={kind}")
+        _require_equal(
+            reason,
+            "MEANING_GENERIC_ALLOW_ALL",
+            f"Expected no kind match for substring-only prompt kind={kind}",
+        )
+
+
+def test_meaning_gate_still_matches_exact_kind_tokens() -> None:
+    """
+    Boundary matching must not over-harden legitimate exact kind mentions.
+    """
+    word_decision, _, word_reason = sim._meaning_gate("Create a document.", "word")
+    excel_decision, excel_layer, excel_reason = sim._meaning_gate("Create a document.", "excel")
+
+    _require_equal(word_decision, "RUN", "Expected exact document token to match word")
+    _require_equal(word_reason, "MEANING_KIND_MATCH", "Expected word kind match")
+    _require_equal(
+        excel_decision,
+        "PAUSE_FOR_HITL",
+        "Expected unrelated kind to pause when another kind is mentioned",
+    )
+    _require_equal(excel_layer, "meaning", "Expected meaning layer pause")
+    _require_equal(
+        excel_reason,
+        "MEANING_KIND_MISSING",
+        "Expected missing kind reason",
+    )
+
+
+def test_strict_contract_validation_rejects_invalid_structures() -> None:
+    """
+    Strict contract validation must reject empty structures, row key drift,
+    and nested Excel cell values.
+    """
+    cases: list[tuple[str, str, dict[str, Any], str]] = [
+        ("excel", "empty columns", {"columns": [], "rows": [{"A": 1}]}, "CONTRACT_EXCEL_COLUMNS_INVALID"),
+        ("excel", "empty rows", {"columns": ["A"], "rows": []}, "CONTRACT_EXCEL_ROWS_INVALID"),
+        ("excel", "row key mismatch", {"columns": ["A"], "rows": [{"B": 1}]}, "CONTRACT_EXCEL_ROW_KEYS_INVALID"),
+        ("excel", "nested dict cell", {"columns": ["A"], "rows": [{"A": {"nested": True}}]}, "CONTRACT_EXCEL_CELL_VALUE_INVALID"),
+        ("excel", "nested list cell", {"columns": ["A"], "rows": [{"A": [1, 2]}]}, "CONTRACT_EXCEL_CELL_VALUE_INVALID"),
+        ("word", "empty headings", {"headings": []}, "CONTRACT_WORD_HEADINGS_INVALID"),
+        ("word", "blank heading", {"headings": [""]}, "CONTRACT_WORD_HEADINGS_INVALID"),
+        ("ppt", "empty slides", {"slides": []}, "CONTRACT_PPT_SLIDES_INVALID"),
+        ("ppt", "blank slide", {"slides": [""]}, "CONTRACT_PPT_SLIDES_INVALID"),
+    ]
+
+    for kind, label, draft, expected_reason in cases:
+        ok, reason = sim._validate_contract(kind, draft)
+        _require(ok is False, f"Expected invalid contract for {label}")
+        _require_equal(reason, expected_reason, f"Unexpected reason for {label}")
+
+
+def test_strict_contract_validation_accepts_valid_structures() -> None:
+    valid_cases: list[tuple[str, dict[str, Any]]] = [
+        (
+            "excel",
+            {
+                "columns": ["A", "B"],
+                "rows": [
+                    {"A": "x", "B": 1},
+                    {"A": None, "B": False},
+                ],
+            },
+        ),
+        ("word", {"headings": ["Title"]}),
+        ("ppt", {"slides": ["Title"]}),
+    ]
+    for kind, draft in valid_cases:
+        ok, reason = sim._validate_contract(kind, draft)
+        _require(ok is True, f"Expected valid contract for kind={kind}")
+        _require_equal(reason, "CONTRACT_OK", f"Unexpected reason for kind={kind}")
+
+
+def test_artifact_path_traversal_is_rejected(tmp_path: Path) -> None:
+    """
+    Artifact writing must reject path traversal task IDs and not create outside files.
+    """
+    artifact_dir = tmp_path / "artifacts"
+    outside = tmp_path / "outside" / "pwned.xlsx.txt"
+
+    try:
+        sim._write_artifact(artifact_dir, "../outside/pwned", "excel", "safe")
+    except ValueError as exc:
+        _require(
+            "unsafe task_id" in str(exc) or "escapes" in str(exc),
+            "Expected unsafe task/path error",
+        )
+    else:
+        _fail("Expected ValueError for path traversal task_id")
+
+    _require(not outside.exists(), "Path traversal created outside artifact file")
+
+
+def test_artifact_write_redacts_email_and_stays_inside_root(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    path = sim._write_artifact(
+        artifact_dir,
+        "safe_task",
+        "word",
+        "Contact: test.user+demo@example.com",
+    )
+    _require(path.exists(), "Expected artifact to be written")
+    _require(
+        path.resolve().is_relative_to(artifact_dir.resolve()),
+        "Expected artifact to remain inside artifact_dir",
+    )
+    content = path.read_text(encoding="utf-8")
+    _require("@" not in content, "Expected redacted artifact content")
+    _require("<REDACTED_EMAIL>" in content, "Expected redaction marker in artifact")
+
+
+def test_break_contract_and_email_leak_stops_at_ethics_before_consistency(tmp_path: Path) -> None:
+    """
+    PII must not be masked by consistency failure.
+    break_contract + leak_email must classify as STOPPED / ethics.
+    """
+    paths = _audit_paths(tmp_path)
+    out = _run(
+        tmp_path=tmp_path,
+        prompt="ドキュメントを作ってください。",
+        run_id="TEST#ETHICS_BEFORE_CONSISTENCY",
+        hitl_choice="CONTINUE",
+        faults={
+            "word": {"break_contract": True, "leak_email": True},
+            "excel": {},
+            "ppt": {},
+        },
+        truncate=True,
+    )
+
+    word_task = _get_task(out, "task_word")
+    _require_equal(word_task.decision, "STOPPED", "Expected word task STOPPED")
+    _require_equal(word_task.blocked_layer, "ethics", "Expected ethics blocked layer")
+    _require_equal(
+        word_task.reason_code,
+        "ETHICS_EMAIL_DETECTED",
+        "Expected ethics email reason",
+    )
+
+    rows = _read_jsonl(paths["audit"])
+    word_events = _events_for_task(rows, "task_word")
+    _require(
+        any(
+            row.get("event") == "GATE_ETHICS"
+            and row.get("decision") == "STOPPED"
+            and row.get("sealed") is True
+            for row in word_events
+        ),
+        "Expected sealed ethics STOPPED event for task_word",
+    )
+    _require(
+        not any(row.get("event") == "GATE_CONSISTENCY" for row in word_events),
+        "GATE_CONSISTENCY should not run after ethics PII preflight STOP",
+    )
+    _assert_no_email_like_persisted(tmp_path / "out")
+
+
+def test_auditlog_write_failures_are_no_raise_and_observable(tmp_path: Path) -> None:
+    """
+    AuditLog intentionally does not raise on I/O failure, but the failure must be observable.
+    """
+    audit_path = tmp_path / "audit_as_directory.jsonl"
+    audit_path.mkdir()
+    audit = sim.AuditLog(audit_path)
+
+    audit.start_run(truncate=True)
+    audit.emit(
+        {
+            "run_id": "AUDIT#FAIL",
+            "task_id": "task_x",
+            "event": "WRITE_FAIL",
+            "layer": "orchestrator",
+            "decision": "RUN",
+            "reason_code": "RC",
+            "sealed": False,
+            "overrideable": False,
+            "final_decider": "SYSTEM",
+        }
+    )
+
+    _require(audit.audit_health.write_failed is True, "Expected audit write failure flag")
+    _require(audit.audit_health.failure_count >= 1, "Expected failure_count >= 1")
+    _require(
+        audit.audit_health.last_error_type in ("IsADirectoryError", "PermissionError", "OSError"),
+        f"Unexpected error type: {audit.audit_health.last_error_type!r}",
+    )
+
+
+def test_run_simulation_exposes_audit_health_on_audit_failure(tmp_path: Path) -> None:
+    audit_path = tmp_path / "audit_dir.jsonl"
+    audit_path.mkdir()
+    result = sim.run_simulation(
+        prompt="ドキュメントを作ってください。",
+        run_id="TEST#AUDIT_HEALTH",
+        audit_path=str(audit_path),
+        artifact_dir=str(tmp_path / "artifacts"),
+        truncate_audit_on_start=True,
+        hitl_resolver=None,
+    )
+    _require(result.audit_health.write_failed is True, "Expected result audit health failure")
+    _require(result.audit_health.failure_count >= 1, "Expected observable failure count")
+
+
+def test_redaction_key_collision_preserves_all_entries(tmp_path: Path) -> None:
+    audit_path = tmp_path / "audit_collision.jsonl"
+    audit = sim.AuditLog(audit_path)
+    audit.start_run(truncate=True)
+    audit.emit(
+        {
+            "run_id": "T#COLLISION",
+            "task_id": "task_x",
+            "event": "COLLISION",
+            "layer": "orchestrator",
+            "decision": "RUN",
+            "reason_code": "RC",
+            "sealed": False,
+            "overrideable": False,
+            "final_decider": "SYSTEM",
+            "evidence": {
+                "a@example.com": "value-a",
+                "b@example.com": "value-b",
+            },
+        }
+    )
+    rows = _read_jsonl(audit_path)
+    _require_equal(len(rows), 1, "Expected one audit row")
+    evidence = rows[0].get("evidence")
+    _require(isinstance(evidence, dict), "Expected evidence mapping")
+    _require("<REDACTED_EMAIL>" in evidence, "Expected first redacted key")
+    _require("<REDACTED_EMAIL>#2" in evidence, "Expected collision-preserved key")
+    _require_equal(evidence["<REDACTED_EMAIL>"], "value-a", "Expected first value")
+    _require_equal(evidence["<REDACTED_EMAIL>#2"], "value-b", "Expected second value")
+    _require("@" not in _blob(rows), "Expected no raw email-like key")
+
+
+def test_hitl_resolver_invalid_return_and_exception_fail_closed(tmp_path: Path) -> None:
+    paths = _audit_paths(tmp_path)
+
+    def invalid_resolver(
+        _run_id: str,
+        _task_id: str,
+        _layer: str,
+        _reason_code: str,
+    ) -> Any:
+        return "MAYBE"
+
+    result_invalid = sim.run_simulation(
+        prompt="Excelの表を作ってください。",
+        run_id="TEST#HITL_INVALID",
+        audit_path=str(paths["audit"]),
+        artifact_dir=str(paths["artifacts"]),
+        truncate_audit_on_start=True,
+        hitl_resolver=invalid_resolver,
+    )
+    rows_invalid = _read_jsonl(paths["audit"])
+    _require_equal(result_invalid.decision, "STOPPED", "Expected invalid resolver STOPPED")
+    _require(
+        any(row.get("event") == "HITL_RESOLVER_FAILED" for row in rows_invalid),
+        "Expected HITL_RESOLVER_FAILED for invalid resolver",
+    )
+
+    def exception_resolver(
+        _run_id: str,
+        _task_id: str,
+        _layer: str,
+        _reason_code: str,
+    ) -> sim.HitlChoice:
+        raise RuntimeError("do not persist this detail")
+
+    result_exception = sim.run_simulation(
+        prompt="Excelの表を作ってください。",
+        run_id="TEST#HITL_EXCEPTION",
+        audit_path=str(paths["audit"]),
+        artifact_dir=str(paths["artifacts"]),
+        truncate_audit_on_start=True,
+        hitl_resolver=exception_resolver,
+    )
+    rows_exception = _read_jsonl(paths["audit"])
+    _require_equal(result_exception.decision, "STOPPED", "Expected exception resolver STOPPED")
+    _require(
+        any(
+            row.get("event") == "HITL_RESOLVER_FAILED"
+            and row.get("error_type") == "RuntimeError"
+            for row in rows_exception
+        ),
+        "Expected RuntimeError type without raw exception detail",
+    )
+    _require(
+        "do not persist this detail" not in _blob(rows_exception),
+        "Raw exception message should not persist",
+    )
+
+
+def test_hitl_resolver_none_fails_closed_without_artifacts_for_stopped_tasks(tmp_path: Path) -> None:
+    paths = _audit_paths(tmp_path)
+    result = sim.run_simulation(
+        prompt="Excelの表を作ってください。",
+        run_id="TEST#HITL_NONE",
+        audit_path=str(paths["audit"]),
+        artifact_dir=str(paths["artifacts"]),
+        truncate_audit_on_start=True,
+        hitl_resolver=None,
+    )
+    _require_equal(result.decision, "STOPPED", "Expected None resolver to fail closed")
+    rows = _read_jsonl(paths["audit"])
+    _require(
+        any(
+            row.get("event") == "HITL_DECIDED"
+            and row.get("decision") == "STOPPED"
+            and row.get("reason_code") == "HITL_STOP"
+            for row in rows
+        ),
+        "Expected HITL_STOP decision for None resolver",
+    )
+
+
+def test_long_audit_non_structural_fields_are_truncated(tmp_path: Path) -> None:
+    audit_path = tmp_path / "audit_long.jsonl"
+    audit = sim.AuditLog(audit_path)
+    audit.start_run(truncate=True)
+    long_note = "X" * (sim.MAX_AUDIT_STRING_LENGTH + 5000)
+    long_run_id = "RUN-" + ("Y" * (sim.MAX_AUDIT_STRING_LENGTH + 10))
+    audit.emit(
+        {
+            "run_id": long_run_id,
+            "task_id": "task_x",
+            "event": "LONG_FIELD",
+            "layer": "orchestrator",
+            "decision": "RUN",
+            "reason_code": "RC",
+            "sealed": False,
+            "overrideable": False,
+            "final_decider": "SYSTEM",
+            "note": long_note,
+        }
+    )
+    rows = _read_jsonl(audit_path)
+    _require_equal(len(rows), 1, "Expected one audit row")
+    _require_equal(rows[0]["run_id"], long_run_id, "Structural run_id should not truncate")
+    note = rows[0].get("note")
+    _require(isinstance(note, str), "Expected note string")
+    _require(sim.TRUNCATION_MARKER in note, "Expected truncation marker")
+    _require(len(note) < len(long_note), "Expected shorter truncated note")
+
+
+def test_rfl_continue_event_order_runs_ethics_acc_before_dispatch(tmp_path: Path) -> None:
+    paths = _audit_paths(tmp_path)
+    out = _run(
+        tmp_path=tmp_path,
+        prompt="おすすめはどっち？",
+        run_id="TEST#RFL_ORDER",
+        hitl_choice="CONTINUE",
+        truncate=True,
+    )
+    _require(bool(out.artifacts_written_task_ids), "Expected artifacts after RFL CONTINUE")
+    rows = _read_jsonl(paths["audit"])
+
+    for task_id in ("task_word", "task_excel", "task_ppt"):
+        events = _events_for_task(rows, task_id)
+        rfl_i = _event_index(events, "GATE_RFL")
+        req_i = _event_index(events, "HITL_REQUESTED")
+        dec_i = _event_index(events, "HITL_DECIDED")
+        ethics_i = _event_index(events, "GATE_ETHICS")
+        acc_i = _event_index(events, "GATE_ACC")
+        write_i = _event_index(events, "ARTIFACT_WRITTEN")
+        _require(
+            rfl_i < req_i < dec_i < ethics_i < acc_i < write_i,
+            f"Unexpected RFL/HITL/Ethics/ACC/Dispatch order for {task_id}",
+        )
+
+
+def test_overall_policy_iep_and_legacy_compatibility(tmp_path: Path) -> None:
+    paths = _audit_paths(tmp_path)
+
+    run_all = sim.run_simulation(
+        prompt="ドキュメントを作ってください。",
+        run_id="TEST#OVERALL_RUN",
+        audit_path=str(paths["audit"]),
+        artifact_dir=str(paths["artifacts"]),
+        truncate_audit_on_start=True,
+        hitl_resolver=None,
+        overall_policy="iep",
+    )
+    _require_equal(run_all.decision, "RUN", "Expected all-run IEP decision")
+
+    def continue_resolver(
+        _run_id: str,
+        _task_id: str,
+        _layer: str,
+        _reason_code: str,
+    ) -> sim.HitlChoice:
+        return "CONTINUE"
+
+    run_pause_iep = sim.run_simulation(
+        prompt="ドキュメントを作ってください。",
+        run_id="TEST#OVERALL_PAUSE_IEP",
+        audit_path=str(paths["audit"]),
+        artifact_dir=str(paths["artifacts"]),
+        faults={"excel": {"break_contract": True}},
+        truncate_audit_on_start=True,
+        hitl_resolver=continue_resolver,
+        overall_policy="iep",
+    )
+    _require_equal(
+        run_pause_iep.decision,
+        "PAUSE_FOR_HITL",
+        "Expected paused IEP decision",
+    )
+
+    run_pause_legacy = sim.run_simulation(
+        prompt="ドキュメントを作ってください。",
+        run_id="TEST#OVERALL_PAUSE_LEGACY",
+        audit_path=str(paths["audit"]),
+        artifact_dir=str(paths["artifacts"]),
+        faults={"excel": {"break_contract": True}},
+        truncate_audit_on_start=True,
+        hitl_resolver=continue_resolver,
+        overall_policy="legacy",
+    )
+    _require_equal(run_pause_legacy.decision, "HITL", "Expected legacy HITL decision")
+
+    run_stop_iep = sim.run_simulation(
+        prompt="ドキュメントを作ってください。",
+        run_id="TEST#OVERALL_STOP_IEP",
+        audit_path=str(paths["audit"]),
+        artifact_dir=str(paths["artifacts"]),
+        faults={"word": {"leak_email": True}},
+        truncate_audit_on_start=True,
+        hitl_resolver=continue_resolver,
+        overall_policy="iep",
+    )
+    _require_equal(run_stop_iep.decision, "STOPPED", "Expected stopped IEP decision")
+


### PR DESCRIPTION
Add strict regression coverage for the hardened v1.2.4 orchestrator.

This is a test-only PR. The source implementation is not changed.

Coverage added/verified:

* meaning gate substring false-positive prevention
* exact kind token matching
* strict contract validation for invalid Excel / Word / PPT structures
* artifact path traversal rejection
* artifact containment and email redaction
* break_contract + leak_email => STOPPED / ethics
* raw_text and raw email-like non-persistence
* AuditLog no-raise failure observability through audit_health
* SimulationResult audit_health propagation
* redaction key collision preservation
* HITL resolver None / invalid / exception fail-closed behavior
* long audit field truncation
* RFL CONTINUE ordering through Ethics / ACC / artifact dispatch
* IEP and legacy overall policy compatibility

Validation:

* py_compile source: PASS
* py_compile tests: PASS
* pytest strict test: 25 passed

Source SHA256:
0636E2CC1C906DC978F7F52DC7B8516EDCEE18C030758071CC53099F8B59F290

Strict test SHA256:
EDD4FD9E80107E07A037842D5B364C96E189FDA34EF7E7C22AC86BDD3AB346C7

Boundary:

* No source change
* No external API access
* No network behavior
* No subprocess / executor behavior
* No automatic fix / apply / commit / push / merge