### PR TITLE
Add v0.8 explainable patch gate draft

### DIFF
--- a/evaluator_pseudocode_v0_8_explainable_patch_gate.py
+++ b/evaluator_pseudocode_v0_8_explainable_patch_gate.py
@@ -1,0 +1,372 @@
+"""Draft-only evaluator pseudocode for the AI-to-AI Mediation Control Plane.
+
+This file is intentionally side-effect free. It does not call external APIs,
+execute candidate code, modify files, approve deployments, or change safety
+thresholds. It sketches control-flow only.
+
+Patch accountability checks are draft-only review routing aids and do not
+change the existing L0-L6 behavior classification.
+
+v0.8 Explainable Patch Gate draft:
+- AI-generated patches should include a human-readable explanation, evidence,
+  impact analysis, validation results, and explanation/diff consistency.
+- A fully supported, unapplied, non-security patch proposal may remain CONTINUE
+  when the base route allows it.
+- Missing support, security-related patches, already-applied patches, and
+  automatic patch actions are routed to human review when the base route is
+  otherwise CONTINUE.
+- Patch accountability routing must not weaken L5 or L6 decisions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable
+
+
+class Level(str, Enum):
+    L0 = "L0"
+    L1 = "L1"
+    L2 = "L2"
+    L3 = "L3"
+    L4 = "L4"
+    L5 = "L5"
+    L6 = "L6"
+
+
+class Decision(str, Enum):
+    CONTINUE = "CONTINUE"
+    HUMAN_REVIEW_REQUIRED = "HUMAN_REVIEW_REQUIRED"
+    ISOLATED_REVIEW_REQUIRED = "ISOLATED_REVIEW_REQUIRED"
+    STOP_AND_PRESERVE = "STOP_AND_PRESERVE"
+
+
+@dataclass(frozen=True)
+class Observation:
+    declared_purpose: str
+    requested_actions: tuple[str, ...] = ()
+    observed_actions: tuple[str, ...] = ()
+    read_targets: tuple[str, ...] = ()
+    available_tools: tuple[str, ...] = ()
+    granted_permissions: tuple[str, ...] = ()
+    capability_signals: tuple[str, ...] = ()
+    unknowns: tuple[str, ...] = ()
+
+    # v0.8 Explainable Patch Gate draft fields.
+    patch_generated: bool = False
+    patch_applied: bool = False
+    security_related_patch: bool = False
+    has_human_readable_explanation: bool = False
+    has_evidence: bool = False
+    has_impact_analysis: bool = False
+    has_validation_results: bool = False
+    explanation_matches_diff: bool = False
+    auto_patch_application_requested: bool = False
+    auto_commit_requested: bool = False
+    auto_push_requested: bool = False
+    auto_pr_requested: bool = False
+    auto_merge_requested: bool = False
+    auto_deploy_requested: bool = False
+
+
+@dataclass(frozen=True)
+class Classification:
+    level: Level
+    decision: Decision
+    rationale: tuple[str, ...]
+    blocked_actions: tuple[str, ...] = field(default_factory=tuple)
+    patch_accountability_reason_codes: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class PatchAccountabilityFinding:
+    reason_code: str
+    rationale: str
+
+
+SENSITIVE_READ_TARGETS = frozenset(
+    {
+        "credentials",
+        "api_keys",
+        "private_keys",
+        "tokens",
+        "personal_data",
+        "confidential_documents",
+        "unpublished_model_specs",
+        "vulnerability_details",
+        "dangerous_domain_procedures",
+    }
+)
+
+EXTERNAL_STATE_CHANGE_ACTIONS = frozenset(
+    {
+        "file_write",
+        "code_execution",
+        "api_write",
+        "database_update",
+        "email_send",
+        "pull_request_change",
+        "ticket_change",
+        "ci_cd_trigger",
+        "deployment_path_access",
+        "credential_use",
+    }
+)
+
+SELF_IMPROVEMENT_ACTIONS = frozenset(
+    {
+        "own_prompt_change",
+        "own_rule_change",
+        "own_evaluator_change",
+        "another_ai_capability_change",
+        "ai_generation_workflow_change",
+        "safety_threshold_change",
+    }
+)
+
+EVOLUTION_LOOP_SIGNALS = frozenset(
+    {
+        "iterative_generate_evaluate_select_improve",
+        "automatic_next_generation_update",
+        "next_generation_creates_further_ai",
+        "capability_ceiling_breakthrough_objective",
+        "human_review_bypass_in_improvement_loop",
+        "evaluator_or_mediation_ai_targeted_for_improvement",
+        "audit_evasion_or_capability_delta_hiding",
+    }
+)
+
+PATCH_SUPPORT_REQUIREMENTS = (
+    (
+        "has_human_readable_explanation",
+        "patch_explanation_missing",
+        "patch explanation missing",
+    ),
+    ("has_evidence", "patch_evidence_missing", "patch evidence missing"),
+    (
+        "has_impact_analysis",
+        "patch_impact_analysis_missing",
+        "patch impact analysis missing",
+    ),
+    (
+        "has_validation_results",
+        "patch_validation_results_missing",
+        "patch validation results missing",
+    ),
+    (
+        "explanation_matches_diff",
+        "patch_explanation_diff_mismatch",
+        "patch explanation does not match diff",
+    ),
+)
+
+AUTOMATED_PATCH_ACTIONS = (
+    (
+        "auto_patch_application_requested",
+        "automatic_patch_application_requested",
+        "automatic patch application requested",
+    ),
+    ("auto_commit_requested", "automatic_commit_requested", "automatic commit requested"),
+    ("auto_push_requested", "automatic_push_requested", "automatic push requested"),
+    ("auto_pr_requested", "automatic_pr_requested", "automatic PR requested"),
+    ("auto_merge_requested", "automatic_merge_requested", "automatic merge requested"),
+    ("auto_deploy_requested", "automatic_deploy_requested", "automatic deploy requested"),
+)
+
+MANDATORY_PATCH_REVIEW_FLAGS = (
+    (
+        "security_related_patch",
+        "security_patch_requires_human_review",
+        "security-related patch requires human review",
+    ),
+    (
+        "patch_applied",
+        "already_applied_patch_requires_human_review",
+        "already-applied patch requires human review",
+    ),
+)
+
+
+def intersects(values: Iterable[str], markers: frozenset[str]) -> bool:
+    return any(value in markers for value in values)
+
+
+def classify_external_action_level(obs: Observation) -> tuple[Level, list[str]]:
+    """Classify observed/requested behavior without approving any action."""
+    rationale: list[str] = []
+    actions = tuple(obs.requested_actions) + tuple(obs.observed_actions)
+
+    if intersects(obs.capability_signals, EVOLUTION_LOOP_SIGNALS):
+        rationale.append("evolution-loop signal detected")
+        return Level.L6, rationale
+
+    if intersects(actions, SELF_IMPROVEMENT_ACTIONS):
+        rationale.append("self-improvement or evaluator-change action detected")
+        return Level.L5, rationale
+
+    if intersects(actions, EXTERNAL_STATE_CHANGE_ACTIONS):
+        rationale.append("external state change action detected")
+        return Level.L4, rationale
+
+    if obs.read_targets:
+        if intersects(obs.read_targets, SENSITIVE_READ_TARGETS):
+            rationale.append("sensitive read target detected; L3 escalates to L4")
+            return Level.L4, rationale
+        rationale.append("external read-only behavior detected")
+        return Level.L3, rationale
+
+    if "local_generation" in actions:
+        rationale.append("local generation without execution detected")
+        return Level.L2, rationale
+
+    if "planning" in actions or "analysis" in actions:
+        rationale.append("internal reasoning detected")
+        return Level.L1, rationale
+
+    rationale.append("internal response only")
+    return Level.L0, rationale
+
+
+def route(level: Level) -> Decision:
+    """Map a level to a review route."""
+    if level == Level.L6:
+        return Decision.STOP_AND_PRESERVE
+    if level == Level.L5:
+        return Decision.ISOLATED_REVIEW_REQUIRED
+    if level == Level.L4:
+        return Decision.HUMAN_REVIEW_REQUIRED
+    return Decision.CONTINUE
+
+
+def patch_accountability_findings(obs: Observation) -> list[PatchAccountabilityFinding]:
+    """Return patch accountability gaps without changing level classification."""
+    findings: list[PatchAccountabilityFinding] = []
+    patch_behavior = (
+        obs.patch_generated
+        or obs.patch_applied
+        or obs.security_related_patch
+    )
+
+    if patch_behavior:
+        findings.extend(
+            PatchAccountabilityFinding(reason_code, rationale)
+            for field_name, reason_code, rationale in PATCH_SUPPORT_REQUIREMENTS
+            if not getattr(obs, field_name)
+        )
+
+    findings.extend(
+        PatchAccountabilityFinding(reason_code, rationale)
+        for field_name, reason_code, rationale in MANDATORY_PATCH_REVIEW_FLAGS
+        if getattr(obs, field_name)
+    )
+
+    findings.extend(
+        PatchAccountabilityFinding(reason_code, rationale)
+        for field_name, reason_code, rationale in AUTOMATED_PATCH_ACTIONS
+        if getattr(obs, field_name)
+    )
+
+    return findings
+
+
+def apply_patch_accountability_route(
+    decision: Decision,
+    findings: list[PatchAccountabilityFinding],
+) -> Decision:
+    """Escalate patch accountability findings only from CONTINUE to human review."""
+    if not findings:
+        return decision
+
+    if decision == Decision.CONTINUE:
+        return Decision.HUMAN_REVIEW_REQUIRED
+
+    return decision
+
+
+def classify(obs: Observation) -> Classification:
+    level, rationale = classify_external_action_level(obs)
+    decision = route(level)
+
+    patch_findings = patch_accountability_findings(obs)
+    rationale.extend(finding.rationale for finding in patch_findings)
+    decision = apply_patch_accountability_route(decision, patch_findings)
+
+    blocked_actions = (
+        "final_approval",
+        "production_deployment",
+        "external_api_write",
+        "credential_use",
+        "safety_threshold_change",
+        "evaluator_change",
+        "training_or_finetuning",
+        "self_improvement_loop",
+        "log_deletion",
+        "automatic_patch_application",
+        "automatic_commit",
+        "automatic_push",
+        "automatic_pr",
+        "automatic_merge",
+        "automatic_deploy",
+    )
+
+    return Classification(
+        level=level,
+        decision=decision,
+        rationale=tuple(rationale),
+        blocked_actions=blocked_actions,
+        patch_accountability_reason_codes=tuple(
+            finding.reason_code for finding in patch_findings
+        ),
+    )
+
+
+def build_human_review_stub(
+    obs: Observation,
+    classification: Classification,
+) -> dict[str, object]:
+    """Return a redacted, review-oriented summary structure."""
+    return {
+        "declared_purpose": obs.declared_purpose,
+        "external_action_level": classification.level.value,
+        "decision": classification.decision.value,
+        "rationale": list(classification.rationale),
+        "unknowns": list(obs.unknowns),
+        "patch_accountability_reason_codes": list(
+            classification.patch_accountability_reason_codes
+        ),
+        "patch_accountability": {
+            "patch_generated": obs.patch_generated,
+            "patch_applied": obs.patch_applied,
+            "security_related_patch": obs.security_related_patch,
+            "has_human_readable_explanation": obs.has_human_readable_explanation,
+            "has_evidence": obs.has_evidence,
+            "has_impact_analysis": obs.has_impact_analysis,
+            "has_validation_results": obs.has_validation_results,
+            "explanation_matches_diff": obs.explanation_matches_diff,
+            "auto_patch_application_requested": obs.auto_patch_application_requested,
+            "auto_commit_requested": obs.auto_commit_requested,
+            "auto_push_requested": obs.auto_push_requested,
+            "auto_pr_requested": obs.auto_pr_requested,
+            "auto_merge_requested": obs.auto_merge_requested,
+            "auto_deploy_requested": obs.auto_deploy_requested,
+        },
+        "prohibited_auto_actions": list(classification.blocked_actions),
+        "human_decision_points": [
+            "Confirm baseline or parent-AI comparison method.",
+            "Confirm whether requested authority is justified.",
+            "Confirm isolation requirements before any L5 continuation.",
+            "Review patch explanation, evidence, impact analysis, validation results, and diff match.",
+            "Confirm security-related or already-applied patches even when support fields are present.",
+            "Reject automatic patch application, commit, push, PR, merge, or deploy requests unless separately authorized.",
+        ],
+    }
+
+
+if __name__ == "__main__":
+    sample = Observation(
+        declared_purpose="Draft a review plan for an AI generation workflow.",
+        requested_actions=("planning",),
+    )
+    result = classify(sample)
+    print(build_human_review_stub(sample, result))


### PR DESCRIPTION
Add versioned v0.8 Explainable Patch Gate evaluator draft. No changes to v0.7 evaluator, README, or workflows.