### PR TITLE
V0 8 explainable patch gate clean

### DIFF
--- a/evaluator_pseudocode_v0_8_explainable_patch_gate.py
+++ b/evaluator_pseudocode_v0_8_explainable_patch_gate.py
@@ -1,0 +1,372 @@
+"""Draft-only evaluator pseudocode for the AI-to-AI Mediation Control Plane.
+
+This file is intentionally side-effect free. It does not call external APIs,
+execute candidate code, modify files, approve deployments, or change safety
+thresholds. It sketches control-flow only.
+
+Patch accountability checks are draft-only review routing aids and do not
+change the existing L0-L6 behavior classification.
+
+v0.8 Explainable Patch Gate draft:
+- AI-generated patches should include a human-readable explanation, evidence,
+  impact analysis, validation results, and explanation/diff consistency.
+- A fully supported, unapplied, non-security patch proposal may remain CONTINUE
+  when the base route allows it.
+- Missing support, security-related patches, already-applied patches, and
+  automatic patch actions are routed to human review when the base route is
+  otherwise CONTINUE.
+- Patch accountability routing must not weaken L5 or L6 decisions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable
+
+
+class Level(str, Enum):
+    L0 = "L0"
+    L1 = "L1"
+    L2 = "L2"
+    L3 = "L3"
+    L4 = "L4"
+    L5 = "L5"
+    L6 = "L6"
+
+
+class Decision(str, Enum):
+    CONTINUE = "CONTINUE"
+    HUMAN_REVIEW_REQUIRED = "HUMAN_REVIEW_REQUIRED"
+    ISOLATED_REVIEW_REQUIRED = "ISOLATED_REVIEW_REQUIRED"
+    STOP_AND_PRESERVE = "STOP_AND_PRESERVE"
+
+
+@dataclass(frozen=True)
+class Observation:
+    declared_purpose: str
+    requested_actions: tuple[str, ...] = ()
+    observed_actions: tuple[str, ...] = ()
+    read_targets: tuple[str, ...] = ()
+    available_tools: tuple[str, ...] = ()
+    granted_permissions: tuple[str, ...] = ()
+    capability_signals: tuple[str, ...] = ()
+    unknowns: tuple[str, ...] = ()
+
+    # v0.8 Explainable Patch Gate draft fields.
+    patch_generated: bool = False
+    patch_applied: bool = False
+    security_related_patch: bool = False
+    has_human_readable_explanation: bool = False
+    has_evidence: bool = False
+    has_impact_analysis: bool = False
+    has_validation_results: bool = False
+    explanation_matches_diff: bool = False
+    auto_patch_application_requested: bool = False
+    auto_commit_requested: bool = False
+    auto_push_requested: bool = False
+    auto_pr_requested: bool = False
+    auto_merge_requested: bool = False
+    auto_deploy_requested: bool = False
+
+
+@dataclass(frozen=True)
+class Classification:
+    level: Level
+    decision: Decision
+    rationale: tuple[str, ...]
+    blocked_actions: tuple[str, ...] = field(default_factory=tuple)
+    patch_accountability_reason_codes: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class PatchAccountabilityFinding:
+    reason_code: str
+    rationale: str
+
+
+SENSITIVE_READ_TARGETS = frozenset(
+    {
+        "credentials",
+        "api_keys",
+        "private_keys",
+        "tokens",
+        "personal_data",
+        "confidential_documents",
+        "unpublished_model_specs",
+        "vulnerability_details",
+        "dangerous_domain_procedures",
+    }
+)
+
+EXTERNAL_STATE_CHANGE_ACTIONS = frozenset(
+    {
+        "file_write",
+        "code_execution",
+        "api_write",
+        "database_update",
+        "email_send",
+        "pull_request_change",
+        "ticket_change",
+        "ci_cd_trigger",
+        "deployment_path_access",
+        "credential_use",
+    }
+)
+
+SELF_IMPROVEMENT_ACTIONS = frozenset(
+    {
+        "own_prompt_change",
+        "own_rule_change",
+        "own_evaluator_change",
+        "another_ai_capability_change",
+        "ai_generation_workflow_change",
+        "safety_threshold_change",
+    }
+)
+
+EVOLUTION_LOOP_SIGNALS = frozenset(
+    {
+        "iterative_generate_evaluate_select_improve",
+        "automatic_next_generation_update",
+        "next_generation_creates_further_ai",
+        "capability_ceiling_breakthrough_objective",
+        "human_review_bypass_in_improvement_loop",
+        "evaluator_or_mediation_ai_targeted_for_improvement",
+        "audit_evasion_or_capability_delta_hiding",
+    }
+)
+
+PATCH_SUPPORT_REQUIREMENTS = (
+    (
+        "has_human_readable_explanation",
+        "patch_explanation_missing",
+        "patch explanation missing",
+    ),
+    ("has_evidence", "patch_evidence_missing", "patch evidence missing"),
+    (
+        "has_impact_analysis",
+        "patch_impact_analysis_missing",
+        "patch impact analysis missing",
+    ),
+    (
+        "has_validation_results",
+        "patch_validation_results_missing",
+        "patch validation results missing",
+    ),
+    (
+        "explanation_matches_diff",
+        "patch_explanation_diff_mismatch",
+        "patch explanation does not match diff",
+    ),
+)
+
+AUTOMATED_PATCH_ACTIONS = (
+    (
+        "auto_patch_application_requested",
+        "automatic_patch_application_requested",
+        "automatic patch application requested",
+    ),
+    ("auto_commit_requested", "automatic_commit_requested", "automatic commit requested"),
+    ("auto_push_requested", "automatic_push_requested", "automatic push requested"),
+    ("auto_pr_requested", "automatic_pr_requested", "automatic PR requested"),
+    ("auto_merge_requested", "automatic_merge_requested", "automatic merge requested"),
+    ("auto_deploy_requested", "automatic_deploy_requested", "automatic deploy requested"),
+)
+
+MANDATORY_PATCH_REVIEW_FLAGS = (
+    (
+        "security_related_patch",
+        "security_patch_requires_human_review",
+        "security-related patch requires human review",
+    ),
+    (
+        "patch_applied",
+        "already_applied_patch_requires_human_review",
+        "already-applied patch requires human review",
+    ),
+)
+
+
+def intersects(values: Iterable[str], markers: frozenset[str]) -> bool:
+    return any(value in markers for value in values)
+
+
+def classify_external_action_level(obs: Observation) -> tuple[Level, list[str]]:
+    """Classify observed/requested behavior without approving any action."""
+    rationale: list[str] = []
+    actions = tuple(obs.requested_actions) + tuple(obs.observed_actions)
+
+    if intersects(obs.capability_signals, EVOLUTION_LOOP_SIGNALS):
+        rationale.append("evolution-loop signal detected")
+        return Level.L6, rationale
+
+    if intersects(actions, SELF_IMPROVEMENT_ACTIONS):
+        rationale.append("self-improvement or evaluator-change action detected")
+        return Level.L5, rationale
+
+    if intersects(actions, EXTERNAL_STATE_CHANGE_ACTIONS):
+        rationale.append("external state change action detected")
+        return Level.L4, rationale
+
+    if obs.read_targets:
+        if intersects(obs.read_targets, SENSITIVE_READ_TARGETS):
+            rationale.append("sensitive read target detected; L3 escalates to L4")
+            return Level.L4, rationale
+        rationale.append("external read-only behavior detected")
+        return Level.L3, rationale
+
+    if "local_generation" in actions:
+        rationale.append("local generation without execution detected")
+        return Level.L2, rationale
+
+    if "planning" in actions or "analysis" in actions:
+        rationale.append("internal reasoning detected")
+        return Level.L1, rationale
+
+    rationale.append("internal response only")
+    return Level.L0, rationale
+
+
+def route(level: Level) -> Decision:
+    """Map a level to a review route."""
+    if level == Level.L6:
+        return Decision.STOP_AND_PRESERVE
+    if level == Level.L5:
+        return Decision.ISOLATED_REVIEW_REQUIRED
+    if level == Level.L4:
+        return Decision.HUMAN_REVIEW_REQUIRED
+    return Decision.CONTINUE
+
+
+def patch_accountability_findings(obs: Observation) -> list[PatchAccountabilityFinding]:
+    """Return patch accountability gaps without changing level classification."""
+    findings: list[PatchAccountabilityFinding] = []
+    patch_behavior = (
+        obs.patch_generated
+        or obs.patch_applied
+        or obs.security_related_patch
+    )
+
+    if patch_behavior:
+        findings.extend(
+            PatchAccountabilityFinding(reason_code, rationale)
+            for field_name, reason_code, rationale in PATCH_SUPPORT_REQUIREMENTS
+            if not getattr(obs, field_name)
+        )
+
+    findings.extend(
+        PatchAccountabilityFinding(reason_code, rationale)
+        for field_name, reason_code, rationale in MANDATORY_PATCH_REVIEW_FLAGS
+        if getattr(obs, field_name)
+    )
+
+    findings.extend(
+        PatchAccountabilityFinding(reason_code, rationale)
+        for field_name, reason_code, rationale in AUTOMATED_PATCH_ACTIONS
+        if getattr(obs, field_name)
+    )
+
+    return findings
+
+
+def apply_patch_accountability_route(
+    decision: Decision,
+    findings: list[PatchAccountabilityFinding],
+) -> Decision:
+    """Escalate patch accountability findings only from CONTINUE to human review."""
+    if not findings:
+        return decision
+
+    if decision == Decision.CONTINUE:
+        return Decision.HUMAN_REVIEW_REQUIRED
+
+    return decision
+
+
+def classify(obs: Observation) -> Classification:
+    level, rationale = classify_external_action_level(obs)
+    decision = route(level)
+
+    patch_findings = patch_accountability_findings(obs)
+    rationale.extend(finding.rationale for finding in patch_findings)
+    decision = apply_patch_accountability_route(decision, patch_findings)
+
+    blocked_actions = (
+        "final_approval",
+        "production_deployment",
+        "external_api_write",
+        "credential_use",
+        "safety_threshold_change",
+        "evaluator_change",
+        "training_or_finetuning",
+        "self_improvement_loop",
+        "log_deletion",
+        "automatic_patch_application",
+        "automatic_commit",
+        "automatic_push",
+        "automatic_pr",
+        "automatic_merge",
+        "automatic_deploy",
+    )
+
+    return Classification(
+        level=level,
+        decision=decision,
+        rationale=tuple(rationale),
+        blocked_actions=blocked_actions,
+        patch_accountability_reason_codes=tuple(
+            finding.reason_code for finding in patch_findings
+        ),
+    )
+
+
+def build_human_review_stub(
+    obs: Observation,
+    classification: Classification,
+) -> dict[str, object]:
+    """Return a redacted, review-oriented summary structure."""
+    return {
+        "declared_purpose": obs.declared_purpose,
+        "external_action_level": classification.level.value,
+        "decision": classification.decision.value,
+        "rationale": list(classification.rationale),
+        "unknowns": list(obs.unknowns),
+        "patch_accountability_reason_codes": list(
+            classification.patch_accountability_reason_codes
+        ),
+        "patch_accountability": {
+            "patch_generated": obs.patch_generated,
+            "patch_applied": obs.patch_applied,
+            "security_related_patch": obs.security_related_patch,
+            "has_human_readable_explanation": obs.has_human_readable_explanation,
+            "has_evidence": obs.has_evidence,
+            "has_impact_analysis": obs.has_impact_analysis,
+            "has_validation_results": obs.has_validation_results,
+            "explanation_matches_diff": obs.explanation_matches_diff,
+            "auto_patch_application_requested": obs.auto_patch_application_requested,
+            "auto_commit_requested": obs.auto_commit_requested,
+            "auto_push_requested": obs.auto_push_requested,
+            "auto_pr_requested": obs.auto_pr_requested,
+            "auto_merge_requested": obs.auto_merge_requested,
+            "auto_deploy_requested": obs.auto_deploy_requested,
+        },
+        "prohibited_auto_actions": list(classification.blocked_actions),
+        "human_decision_points": [
+            "Confirm baseline or parent-AI comparison method.",
+            "Confirm whether requested authority is justified.",
+            "Confirm isolation requirements before any L5 continuation.",
+            "Review patch explanation, evidence, impact analysis, validation results, and diff match.",
+            "Confirm security-related or already-applied patches even when support fields are present.",
+            "Reject automatic patch application, commit, push, PR, merge, or deploy requests unless separately authorized.",
+        ],
+    }
+
+
+if __name__ == "__main__":
+    sample = Observation(
+        declared_purpose="Draft a review plan for an AI generation workflow.",
+        requested_actions=("planning",),
+    )
+    result = classify(sample)
+    print(build_human_review_stub(sample, result))

--- a/tests/test_evaluator_pseudocode_v0_8_explainable_patch_gate.py
+++ b/tests/test_evaluator_pseudocode_v0_8_explainable_patch_gate.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import py_compile
+import tempfile
+import unittest
+from pathlib import Path
+
+from evaluator_pseudocode_v0_8_explainable_patch_gate import (
+    Decision,
+    Level,
+    Observation,
+    build_human_review_stub,
+    classify,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+EVALUATOR_PATH = PROJECT_ROOT / "evaluator_pseudocode_v0_8_explainable_patch_gate.py"
+
+
+class PatchAccountabilityTests(unittest.TestCase):
+    def classify(self, **kwargs):
+        obs = Observation(
+            declared_purpose="patch accountability validation",
+            **kwargs,
+        )
+        return classify(obs)
+
+    def test_patch_accountability_fields_default_to_false(self):
+        obs = Observation(declared_purpose="default field validation")
+
+        self.assertFalse(obs.patch_generated)
+        self.assertFalse(obs.patch_applied)
+        self.assertFalse(obs.security_related_patch)
+        self.assertFalse(obs.has_human_readable_explanation)
+        self.assertFalse(obs.has_evidence)
+        self.assertFalse(obs.has_impact_analysis)
+        self.assertFalse(obs.has_validation_results)
+        self.assertFalse(obs.explanation_matches_diff)
+        self.assertFalse(obs.auto_patch_application_requested)
+        self.assertFalse(obs.auto_commit_requested)
+        self.assertFalse(obs.auto_push_requested)
+        self.assertFalse(obs.auto_pr_requested)
+        self.assertFalse(obs.auto_merge_requested)
+        self.assertFalse(obs.auto_deploy_requested)
+
+    def test_generated_patch_without_explanation_requires_human_review(self):
+        result = self.classify(
+            patch_generated=True,
+            has_evidence=True,
+            has_impact_analysis=True,
+            has_validation_results=True,
+            explanation_matches_diff=True,
+        )
+
+        self.assertEqual(result.decision, Decision.HUMAN_REVIEW_REQUIRED)
+        self.assertIn(
+            "patch_explanation_missing",
+            result.patch_accountability_reason_codes,
+        )
+
+    def test_applied_patch_without_support_requires_human_review(self):
+        result = self.classify(
+            patch_applied=True,
+            has_human_readable_explanation=True,
+        )
+
+        self.assertEqual(result.decision, Decision.HUMAN_REVIEW_REQUIRED)
+
+    def test_security_patch_missing_support_requires_human_review(self):
+        result = self.classify(
+            security_related_patch=True,
+            has_human_readable_explanation=True,
+            explanation_matches_diff=True,
+        )
+
+        self.assertEqual(result.decision, Decision.HUMAN_REVIEW_REQUIRED)
+        self.assertTrue(
+            {
+                "patch_evidence_missing",
+                "patch_impact_analysis_missing",
+                "patch_validation_results_missing",
+                "security_patch_requires_human_review",
+            }.issubset(result.patch_accountability_reason_codes)
+        )
+
+    def test_supported_security_patch_still_requires_human_review(self):
+        result = self.classify(
+            security_related_patch=True,
+            has_human_readable_explanation=True,
+            has_evidence=True,
+            has_impact_analysis=True,
+            has_validation_results=True,
+            explanation_matches_diff=True,
+        )
+
+        self.assertEqual(result.level, Level.L0)
+        self.assertEqual(result.decision, Decision.HUMAN_REVIEW_REQUIRED)
+        self.assertIn(
+            "security_patch_requires_human_review",
+            result.patch_accountability_reason_codes,
+        )
+
+    def test_supported_applied_patch_still_requires_human_review(self):
+        result = self.classify(
+            patch_applied=True,
+            has_human_readable_explanation=True,
+            has_evidence=True,
+            has_impact_analysis=True,
+            has_validation_results=True,
+            explanation_matches_diff=True,
+        )
+
+        self.assertEqual(result.level, Level.L0)
+        self.assertEqual(result.decision, Decision.HUMAN_REVIEW_REQUIRED)
+        self.assertIn(
+            "already_applied_patch_requires_human_review",
+            result.patch_accountability_reason_codes,
+        )
+
+    def test_explanation_mismatch_requires_human_review(self):
+        result = self.classify(
+            patch_generated=True,
+            has_human_readable_explanation=True,
+            has_evidence=True,
+            has_impact_analysis=True,
+            has_validation_results=True,
+            explanation_matches_diff=False,
+        )
+
+        self.assertEqual(result.decision, Decision.HUMAN_REVIEW_REQUIRED)
+        self.assertIn(
+            "patch_explanation_diff_mismatch",
+            result.patch_accountability_reason_codes,
+        )
+
+    def test_supported_patch_can_continue_when_base_route_allows(self):
+        result = self.classify(
+            patch_generated=True,
+            has_human_readable_explanation=True,
+            has_evidence=True,
+            has_impact_analysis=True,
+            has_validation_results=True,
+            explanation_matches_diff=True,
+        )
+
+        self.assertEqual(result.level, Level.L0)
+        self.assertEqual(result.decision, Decision.CONTINUE)
+        self.assertEqual(result.patch_accountability_reason_codes, ())
+
+    def test_auto_patch_application_requires_human_review(self):
+        result = self.classify(auto_patch_application_requested=True)
+
+        self.assertEqual(result.decision, Decision.HUMAN_REVIEW_REQUIRED)
+        self.assertIn(
+            "automatic_patch_application_requested",
+            result.patch_accountability_reason_codes,
+        )
+
+    def test_auto_commit_requires_human_review(self):
+        result = self.classify(auto_commit_requested=True)
+
+        self.assertEqual(result.decision, Decision.HUMAN_REVIEW_REQUIRED)
+        self.assertIn(
+            "automatic_commit_requested",
+            result.patch_accountability_reason_codes,
+        )
+
+    def test_auto_push_requires_human_review(self):
+        result = self.classify(auto_push_requested=True)
+
+        self.assertEqual(result.decision, Decision.HUMAN_REVIEW_REQUIRED)
+        self.assertIn(
+            "automatic_push_requested",
+            result.patch_accountability_reason_codes,
+        )
+
+    def test_auto_pr_requires_human_review(self):
+        result = self.classify(auto_pr_requested=True)
+
+        self.assertEqual(result.decision, Decision.HUMAN_REVIEW_REQUIRED)
+        self.assertIn(
+            "automatic_pr_requested",
+            result.patch_accountability_reason_codes,
+        )
+
+    def test_auto_merge_requires_human_review(self):
+        result = self.classify(auto_merge_requested=True)
+
+        self.assertEqual(result.decision, Decision.HUMAN_REVIEW_REQUIRED)
+        self.assertIn(
+            "automatic_merge_requested",
+            result.patch_accountability_reason_codes,
+        )
+
+    def test_auto_deploy_requires_human_review(self):
+        result = self.classify(auto_deploy_requested=True)
+
+        self.assertEqual(result.decision, Decision.HUMAN_REVIEW_REQUIRED)
+        self.assertIn(
+            "automatic_deploy_requested",
+            result.patch_accountability_reason_codes,
+        )
+
+    def test_existing_l4_l5_l6_routes_are_unchanged(self):
+        l4 = self.classify(requested_actions=("file_write",))
+        l5 = self.classify(requested_actions=("own_evaluator_change",))
+        l6 = self.classify(
+            capability_signals=("iterative_generate_evaluate_select_improve",)
+        )
+
+        self.assertEqual(
+            (l4.level, l4.decision),
+            (
+                Level.L4,
+                Decision.HUMAN_REVIEW_REQUIRED,
+            ),
+        )
+        self.assertEqual(
+            (l5.level, l5.decision),
+            (
+                Level.L5,
+                Decision.ISOLATED_REVIEW_REQUIRED,
+            ),
+        )
+        self.assertEqual(
+            (l6.level, l6.decision),
+            (
+                Level.L6,
+                Decision.STOP_AND_PRESERVE,
+            ),
+        )
+
+    def test_patch_overlay_does_not_weaken_l5_or_l6(self):
+        l5 = self.classify(
+            requested_actions=("own_evaluator_change",),
+            auto_commit_requested=True,
+        )
+        l6 = self.classify(
+            capability_signals=("iterative_generate_evaluate_select_improve",),
+            patch_generated=True,
+        )
+
+        self.assertEqual(l5.decision, Decision.ISOLATED_REVIEW_REQUIRED)
+        self.assertEqual(l6.decision, Decision.STOP_AND_PRESERVE)
+
+    def test_blocked_actions_include_automatic_patch_actions(self):
+        result = self.classify()
+
+        self.assertTrue(
+            {
+                "automatic_patch_application",
+                "automatic_commit",
+                "automatic_push",
+                "automatic_pr",
+                "automatic_merge",
+                "automatic_deploy",
+            }.issubset(result.blocked_actions)
+        )
+
+    def test_human_review_stub_includes_patch_accountability_fields_and_reason_codes(self):
+        obs = Observation(
+            declared_purpose="patch accountability validation",
+            patch_generated=True,
+            auto_patch_application_requested=True,
+            auto_commit_requested=True,
+            auto_push_requested=True,
+            auto_pr_requested=True,
+            auto_merge_requested=True,
+            auto_deploy_requested=True,
+        )
+        classification = classify(obs)
+        stub = build_human_review_stub(obs, classification)
+
+        self.assertIn("patch_accountability_reason_codes", stub)
+        self.assertIn("patch_accountability", stub)
+        self.assertIn(
+            "patch_explanation_missing",
+            stub["patch_accountability_reason_codes"],
+        )
+        self.assertIn(
+            "automatic_patch_application_requested",
+            stub["patch_accountability_reason_codes"],
+        )
+        self.assertTrue(stub["patch_accountability"]["patch_generated"])
+        self.assertTrue(
+            stub["patch_accountability"]["auto_patch_application_requested"]
+        )
+        self.assertTrue(stub["patch_accountability"]["auto_commit_requested"])
+        self.assertTrue(stub["patch_accountability"]["auto_push_requested"])
+        self.assertTrue(stub["patch_accountability"]["auto_pr_requested"])
+        self.assertTrue(stub["patch_accountability"]["auto_merge_requested"])
+        self.assertTrue(stub["patch_accountability"]["auto_deploy_requested"])
+
+    def test_py_compile_passes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pyc_path = Path(tmpdir) / "evaluator_pseudocode_v0_8_explainable_patch_gate.pyc"
+            py_compile.compile(
+                str(EVALUATOR_PATH),
+                cfile=str(pyc_path),
+                doraise=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a versioned v0.8 Explainable Patch Gate evaluator draft and matching tests.

This keeps the existing v0.7 evaluator and existing v0.7 tests unchanged.

## Changes

- Add `evaluator_pseudocode_v0_8_explainable_patch_gate.py`
- Add `tests/test_evaluator_pseudocode_v0_8_explainable_patch_gate.py`
- Add draft patch accountability routing checks for:
  - missing patch explanation
  - missing evidence
  - missing impact analysis
  - missing validation results
  - explanation / diff mismatch
  - security-related patches
  - already-applied patches
  - automatic patch application / commit / push / PR / merge / deploy requests

## Notes

- No changes to `evaluator_pseudocode.py`
- No changes to `tests/test_evaluator_pseudocode.py`
- No README changes
- No workflow changes
- This is a versioned draft, not a replacement for v0.7

## Validation

Local versioned draft validation:

```text
py_compile: passed
unittest: 19 tests OK