### PR TITLE
Clarify v0.8 patch rationale handling

### DIFF
--- a/evaluator_pseudocode_v0_8_explainable_patch_gate.py
+++ b/evaluator_pseudocode_v0_8_explainable_patch_gate.py
@@ -289,7 +289,8 @@ def classify(obs: Observation) -> Classification:
     decision = route(level)
 
     patch_findings = patch_accountability_findings(obs)
-    rationale.extend(finding.rationale for finding in patch_findings)
+    for finding in patch_findings:
+        rationale.append(finding.rationale)
     decision = apply_patch_accountability_route(decision, patch_findings)
 
     blocked_actions = (

--- a/tests/test_evaluator_pseudocode_v0_8_explainable_patch_gate.py
+++ b/tests/test_evaluator_pseudocode_v0_8_explainable_patch_gate.py
@@ -14,8 +14,11 @@ from evaluator_pseudocode_v0_8_explainable_patch_gate import (
 )
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TEST_PATH = Path(__file__).resolve()
+PROJECT_ROOT = TEST_PATH.parents[1]
 EVALUATOR_PATH = PROJECT_ROOT / "evaluator_pseudocode_v0_8_explainable_patch_gate.py"
+if not EVALUATOR_PATH.exists():
+    EVALUATOR_PATH = TEST_PATH.parent / "evaluator_pseudocode_v0_8_explainable_patch_gate.py"
 
 
 class PatchAccountabilityTests(unittest.TestCase):
@@ -133,6 +136,12 @@ class PatchAccountabilityTests(unittest.TestCase):
             "patch_explanation_diff_mismatch",
             result.patch_accountability_reason_codes,
         )
+
+    def test_patch_rationale_entries_are_full_strings(self):
+        result = self.classify(patch_generated=True)
+
+        self.assertIn("patch explanation missing", result.rationale)
+        self.assertNotIn("p", result.rationale)
 
     def test_supported_patch_can_continue_when_base_route_allows(self):
         result = self.classify(


### PR DESCRIPTION
## Summary

Clarify patch-accountability rationale handling in the v0.8 Explainable Patch Gate evaluator.

## Changes

* Replace generator-based `rationale.extend(...)` with an explicit append loop.
* Add regression coverage confirming patch rationale entries are stored as full strings.
* Keep existing L5/L6 non-weakening behavior unchanged.
* Keep evaluator path resolution robust for both repository and side-by-side local test layouts.

## Notes

* No changes to `evaluator_pseudocode.py`.
* No README changes.
* No workflow changes.
* No behavior change intended beyond readability and regression coverage.

## Validation

```text
python -B -m pytest -q -p no:cacheprovider test_evaluator_pseudocode_v0_8_explainable_patch_gate.py
20 passed in 0.08s
```
