### PR TITLE
Add explainable patch proposal accountability gate

### DIFF
--- a/.github/workflows/tasukeru-analysis.yml
+++ b/.github/workflows/tasukeru-analysis.yml
@@ -470,6 +470,9 @@ jobs:
           probabilistic_escalation_md_path = Path("tasukeru_probabilistic_escalation_report.md")
           probabilistic_escalation_json_path = Path("tasukeru_probabilistic_escalation_report.json")
           probabilistic_escalation_verify_path = Path("tasukeru_probabilistic_escalation_verify.json")
+          explainable_patch_proposals_md_path = Path("tasukeru_explainable_patch_proposals.md")
+          explainable_patch_proposals_json_path = Path("tasukeru_explainable_patch_proposals.json")
+          explainable_patch_proposals_verify_path = Path("tasukeru_explainable_patch_proposals_verify.json")
 
           AUTO_FALSE = {
               "auto_branch_allowed": False,
@@ -2878,6 +2881,896 @@ jobs:
               file_obj.write(f"  - Autofix policy: `{entry.get('autofix', {}).get('policy', 'AUTOFIX_BLOCKED')}`\n")
               file_obj.write(f"  - Fingerprint: `{entry['fingerprint_hash']}`\n")
 
+          def is_patch_security_related(entry: dict[str, Any]) -> bool:
+              source = str(entry.get("source", "")).lower()
+              category = str(entry.get("category", "")).lower()
+              reason_code = str(entry.get("reason_code", "")).lower()
+              message = str(entry.get("message", "")).lower()
+              suggestion = str(entry.get("suggestion", "")).lower()
+              blob = " ".join([source, category, reason_code, message, suggestion])
+              security_sources = {
+                  "bandit",
+                  "pip-audit",
+                  "tasukeru abuse pattern review",
+                  "tasukeru logic review",
+                  "tasukeru self-definition guard",
+              }
+              if source in security_sources:
+                  return True
+              security_tokens = (
+                  "security",
+                  "safety",
+                  "vulnerability",
+                  "credential",
+                  "secret",
+                  "token",
+                  "api key",
+                  "private key",
+                  "hitl",
+                  "abuse",
+                  "exploit",
+                  "bypass",
+                  "invariant",
+              )
+              return any(token in blob for token in security_tokens)
+
+          def build_patch_accountability_reason_codes(
+              *,
+              has_human_readable_explanation: bool,
+              has_evidence: bool,
+              has_impact_analysis: bool,
+              has_validation_support: bool,
+              reasoning_chain_complete: bool,
+              explanation_matches_proposal: bool,
+              explanation_matches_diff: bool | None,
+              patch_applied: bool,
+              security_related_patch: bool,
+              auto_action_requested: bool,
+              candidate_diff_generated: bool,
+              supported: bool,
+          ) -> list[str]:
+              reason_codes: list[str] = [
+                  "evidence_backed_draft_fix" if supported else "invalid_draft_fix_error"
+              ]
+              if not has_human_readable_explanation:
+                  reason_codes.append("fix_explanation_missing")
+              if not has_evidence:
+                  reason_codes.append("fix_evidence_missing")
+              if not has_impact_analysis:
+                  reason_codes.append("fix_impact_analysis_missing")
+              if not has_validation_support:
+                  reason_codes.append("fix_validation_results_missing")
+              if not reasoning_chain_complete:
+                  reason_codes.append("fix_reasoning_chain_broken")
+              if not explanation_matches_proposal:
+                  reason_codes.append("fix_explanation_proposal_mismatch")
+              if candidate_diff_generated and explanation_matches_diff is not True:
+                  reason_codes.append("fix_explanation_diff_mismatch")
+              if security_related_patch:
+                  reason_codes.append("security_patch_requires_human_review")
+              if patch_applied:
+                  reason_codes.append("already_applied_patch_requires_human_review")
+              if auto_action_requested:
+                  reason_codes.append("automatic_patch_action_requested")
+              if not candidate_diff_generated:
+                  reason_codes.append("candidate_diff_not_generated_advisory_only")
+              reason_codes.extend(
+                  [
+                      "automatic_patch_application_blocked",
+                      "automatic_commit_blocked",
+                      "automatic_push_blocked",
+                      "automatic_pr_creation_blocked",
+                      "automatic_merge_blocked",
+                      "automatic_deploy_blocked",
+                  ]
+              )
+              return list(dict.fromkeys(reason_codes))
+
+          def has_support_content(value: Any) -> bool:
+              if value is None:
+                  return False
+              if isinstance(value, str):
+                  return bool(value.strip())
+              if isinstance(value, dict):
+                  return any(has_support_content(item) for item in value.values())
+              if isinstance(value, (list, tuple, set)):
+                  return any(has_support_content(item) for item in value)
+              return True
+
+          def support_text(value: Any) -> str:
+              if value is None:
+                  return ""
+              if isinstance(value, str):
+                  return value
+              if isinstance(value, dict):
+                  return " ".join(support_text(item) for item in value.values())
+              if isinstance(value, (list, tuple, set)):
+                  return " ".join(support_text(item) for item in value)
+              return str(value)
+
+          def explanation_matches_proposed_fix(
+              explanation: dict[str, Any],
+              proposed_fix: dict[str, Any],
+          ) -> bool:
+              explanation_blob = support_text(explanation).strip().lower()
+              proposed_blob = support_text(proposed_fix).strip().lower()
+              if not explanation_blob or not proposed_blob:
+                  return False
+
+              summary = str(explanation.get("summary_ja", "")).strip().lower()
+              why_fix = str(explanation.get("why_fix_ja", "")).strip().lower()
+              if summary and summary in proposed_blob:
+                  return True
+              if why_fix and why_fix in proposed_blob:
+                  return True
+
+              explanation_tokens = {
+                  token
+                  for token in re.findall(r"[a-z0-9_]{4,}", explanation_blob)
+                  if token not in {"this", "that", "with", "from", "candidate", "proposal"}
+              }
+              proposed_tokens = set(re.findall(r"[a-z0-9_]{4,}", proposed_blob))
+              if not explanation_tokens or not proposed_tokens:
+                  return False
+              overlap = len(explanation_tokens & proposed_tokens)
+              return overlap / max(1, min(len(explanation_tokens), len(proposed_tokens))) >= 0.2
+
+          def build_explainable_patch_validation_plan(entry: dict[str, Any]) -> list[str]:
+              source = str(entry.get("source", "Tasukeru"))
+              rule_id = str(entry.get("rule_id", entry.get("reason_code", "")))
+              return [
+                  "Human reviewer confirms the observed issue and source evidence are present.",
+                  f"Human reviewer checks the proposed remediation against `{source}` / `{rule_id}`.",
+                  "Human reviewer confirms the change is appropriate for the path profile and existing contract.",
+                  "Run targeted tests, lint, or static analysis appropriate to the touched file before adopting any change.",
+                  "Confirm no auto apply, commit, push, PR creation, merge, or deploy was performed by Tasukeru.",
+              ]
+
+          def build_explainable_patch_validation_results(entry: dict[str, Any]) -> list[dict[str, Any]]:
+              file_path = normalize_path(str(entry.get("file", "")))
+              target_path = Path(file_path) if file_path else None
+              validation_results = [
+                  {
+                      "check": "repository_modification",
+                      "status": "passed",
+                      "detail": "This workflow did not modify repository files while generating the proposal.",
+                  },
+                  {
+                      "check": "candidate_application",
+                      "status": "not_applied",
+                      "detail": "The proposal is draft-only and requires a human-created or human-approved patch.",
+                  },
+                  {
+                      "check": "automatic_actions",
+                      "status": "blocked",
+                      "detail": "Auto apply, commit, push, PR creation, merge, and deploy remain disabled.",
+                  },
+              ]
+              if target_path and target_path.exists() and target_path.is_file():
+                  validation_results.append(
+                      {
+                          "check": "target_file_readable",
+                          "status": "passed",
+                          "file": file_path,
+                          "sha256": sha256_text(read_text(target_path)),
+                      }
+                  )
+              elif file_path:
+                  validation_results.append(
+                      {
+                          "check": "target_file_readable",
+                          "status": "not_available",
+                          "file": file_path,
+                          "detail": "The target path was not present in the checked-out workspace.",
+                      }
+                  )
+              else:
+                  validation_results.append(
+                      {
+                          "check": "target_file_identified",
+                          "status": "not_available",
+                          "detail": "The finding did not include a concrete file path.",
+                      }
+                  )
+              return validation_results
+
+          def check_explainable_patch_support(
+              *,
+              evidence: dict[str, Any],
+              explanation: dict[str, Any],
+              impact_analysis: dict[str, Any],
+              candidate_patch: dict[str, Any],
+              validation_plan: list[str],
+              validation_results: list[dict[str, Any]],
+              reasoning_chain: dict[str, Any],
+              policy: dict[str, Any],
+              candidate_diff_generated: bool,
+              explanation_matches_diff: bool | None,
+              patch_applied: bool,
+              security_related_patch: bool,
+          ) -> dict[str, Any]:
+              has_human_readable_explanation = has_support_content(explanation)
+              has_evidence = has_support_content(evidence)
+              has_impact_analysis = has_support_content(impact_analysis)
+              has_validation_plan = has_support_content(validation_plan)
+              has_validation_results = has_support_content(validation_results)
+              has_validation_support = has_validation_plan or has_validation_results
+              explanation_matches_proposal = explanation_matches_proposed_fix(explanation, candidate_patch)
+              required_chain_fields = (
+                  "observed_issue",
+                  "evidence",
+                  "why_this_matters",
+                  "proposed_fix",
+                  "why_this_fix",
+                  "impact_analysis",
+                  "validation",
+                  "human_review_required",
+                  "hash_chain_entry",
+              )
+              reasoning_chain_complete = all(
+                  has_support_content(reasoning_chain.get(field))
+                  for field in required_chain_fields
+              ) and reasoning_chain.get("human_review_required") is True
+              auto_flags = (
+                  "auto_apply_allowed",
+                  "auto_commit_allowed",
+                  "auto_push_allowed",
+                  "auto_pr_creation_allowed",
+                  "auto_merge_allowed",
+                  "auto_deploy_allowed",
+              )
+              external_state_changes_blocked = all(
+                  policy.get(flag) is False for flag in auto_flags
+              )
+              human_decision_required = policy.get("human_decision_required") is True
+              diff_support_ok = (
+                  explanation_matches_diff is True
+                  if candidate_diff_generated
+                  else explanation_matches_diff is None
+              )
+              supported = all(
+                  [
+                      has_human_readable_explanation,
+                      has_evidence,
+                      has_impact_analysis,
+                      has_validation_support,
+                      reasoning_chain_complete,
+                      explanation_matches_proposal,
+                      diff_support_ok,
+                      external_state_changes_blocked,
+                      human_decision_required,
+                      not patch_applied,
+                  ]
+              )
+              reason_codes = build_patch_accountability_reason_codes(
+                  has_human_readable_explanation=has_human_readable_explanation,
+                  has_evidence=has_evidence,
+                  has_impact_analysis=has_impact_analysis,
+                  has_validation_support=has_validation_support,
+                  reasoning_chain_complete=reasoning_chain_complete,
+                  explanation_matches_proposal=explanation_matches_proposal,
+                  explanation_matches_diff=explanation_matches_diff,
+                  patch_applied=patch_applied,
+                  security_related_patch=security_related_patch,
+                  auto_action_requested=False,
+                  candidate_diff_generated=candidate_diff_generated,
+                  supported=supported,
+              )
+              invalid_reason_codes = [
+                  code
+                  for code in reason_codes
+                  if code.startswith("fix_") or code == "invalid_draft_fix_error"
+              ]
+              return {
+                  "is_supported": supported,
+                  "proposal_status": "EVIDENCE_BACKED_DRAFT_FIX" if supported else "INVALID_DRAFT_FIX_ERROR",
+                  "proposal_kind": "MANUAL_REMEDIATION_OUTLINE"
+                  if not candidate_diff_generated
+                  else "DIFF_BACKED_DRAFT_FIX",
+                  "has_human_readable_explanation": has_human_readable_explanation,
+                  "has_evidence": has_evidence,
+                  "has_impact_analysis": has_impact_analysis,
+                  "has_validation_plan": has_validation_plan,
+                  "has_validation_results": has_validation_results,
+                  "has_validation_support": has_validation_support,
+                  "reasoning_chain_complete": reasoning_chain_complete,
+                  "explanation_matches_proposal": explanation_matches_proposal,
+                  "explanation_matches_diff": explanation_matches_diff,
+                  "diff_support_ok": diff_support_ok,
+                  "external_state_changes_blocked": external_state_changes_blocked,
+                  "human_decision_required": human_decision_required,
+                  "reason_codes": reason_codes,
+                  "invalid_reason_codes": invalid_reason_codes,
+              }
+
+          def build_explainable_patch_candidate(entry: dict[str, Any], index: int) -> dict[str, Any]:
+              evidence = entry.get("evidence", {})
+              if not isinstance(evidence, dict):
+                  evidence = {}
+              explanation = entry.get("explanation", {})
+              if not isinstance(explanation, dict):
+                  explanation = {}
+              fix_prediction = entry.get("fix_prediction", {})
+              if not isinstance(fix_prediction, dict):
+                  fix_prediction = {}
+
+              file_path = normalize_path(str(entry.get("file", "")))
+              line = entry.get("line")
+              location = file_path or "repository"
+              if line:
+                  location = f"{location}:{line}"
+              snippet = str(entry.get("code_snippet") or safe_snippet(file_path, line))
+              suggestion = one_line(entry.get("suggestion", ""), 1000)
+              message = one_line(entry.get("message", ""), 1000)
+              fingerprint_hash = str(entry.get("fingerprint_hash") or canonical_hash(entry))
+              proposal_id = f"EPP-{index:04d}-{fingerprint_hash[:12]}"
+              security_related_patch = is_patch_security_related(entry)
+              validation_results = build_explainable_patch_validation_results(entry)
+              validation_plan = build_explainable_patch_validation_plan(entry)
+              candidate_diff_generated = False
+              explanation_matches_diff = None
+              patch_applied = False
+
+              manual_steps = [
+                  f"対象 `{location}` を人間が確認する",
+                  suggestion or "finding の message と evidence を確認して修正方針を決める",
+                  explanation.get("why_fix_ja", "根拠と修正方針の対応を人間が確認する"),
+                  "差分を作る場合は人間が内容を確認し、必要なテストまたは静的解析を実行する",
+                  "Tasukeru の advisory artifact と reason_code を根拠として記録する",
+              ]
+              source_entry = {
+                  "incident_id": entry.get("incident_id"),
+                  "decision": entry.get("decision"),
+                  "severity": entry.get("severity"),
+                  "source": entry.get("source"),
+                  "category": entry.get("category"),
+                  "reason_code": entry.get("reason_code"),
+                  "rule_id": entry.get("rule_id"),
+                  "file": file_path,
+                  "line": line,
+                  "column": entry.get("column"),
+                  "path_profile": entry.get("path_profile"),
+                  "fingerprint_hash": fingerprint_hash,
+              }
+              human_readable_explanation = {
+                  "summary_ja": suggestion,
+                  "why_problematic_ja": explanation.get("why_problematic_ja", ""),
+                  "why_fix_ja": explanation.get("why_fix_ja", ""),
+                  "why_this_classification_ja": explanation.get("why_this_classification_ja", ""),
+                  "message": message,
+                  "rule": (
+                      "A fix proposal that cannot explain why this fix follows from this evidence "
+                      "is not a valid proposal."
+                  ),
+              }
+              evidence_payload = {
+                  **evidence,
+                  "observed_issue": message,
+                  "message": message,
+                  "code_snippet": snippet,
+                  "confidence": entry.get("confidence"),
+                  "confidence_score": entry.get("confidence_score"),
+                  "confidence_reasons": entry.get("confidence_reasons", []),
+              }
+              impact_analysis = {
+                  "expected_effect_ja": fix_prediction.get("expected_effect_ja", ""),
+                  "expected_effect_en": fix_prediction.get("expected_effect_en", ""),
+                  "risk_reduction_ja": fix_prediction.get("risk_reduction_ja", ""),
+                  "side_effects_to_check_ja": fix_prediction.get("side_effects_to_check_ja", []),
+                  "classification_reason": entry.get("classification_reason", ""),
+              }
+              candidate_patch = {
+                  "kind": "manual_remediation_outline",
+                  "manual_steps_ja": manual_steps,
+                  "proposed_fix": suggestion,
+                  "unified_diff": "",
+                  "candidate_diff_generated": candidate_diff_generated,
+                  "diff_artifact": "",
+                  "reason_no_diff": (
+                      "Tasukeru generates evidence-backed draft proposals only. "
+                      "It does not synthesize or apply repository diffs automatically."
+                  ),
+              }
+              policy = {
+                  "auto_apply_allowed": False,
+                  "auto_commit_allowed": False,
+                  "auto_push_allowed": False,
+                  "auto_pr_creation_allowed": False,
+                  "auto_merge_allowed": False,
+                  "auto_deploy_allowed": False,
+                  "human_decision_required": True,
+                  "suggestion_only": True,
+              }
+              reasoning_chain = {
+                  "observed_issue": message,
+                  "evidence": evidence_payload,
+                  "why_this_matters": human_readable_explanation.get("why_problematic_ja", ""),
+                  "proposed_fix": candidate_patch,
+                  "why_this_fix": human_readable_explanation.get("why_fix_ja", ""),
+                  "impact_analysis": impact_analysis,
+                  "validation": {
+                      "validation_plan": validation_plan,
+                      "validation_results": validation_results,
+                  },
+                  "human_review_required": True,
+                  "hash_chain_entry": "integrity.chain_hash",
+              }
+              support = check_explainable_patch_support(
+                  evidence=evidence_payload,
+                  explanation=human_readable_explanation,
+                  impact_analysis=impact_analysis,
+                  candidate_patch=candidate_patch,
+                  validation_plan=validation_plan,
+                  validation_results=validation_results,
+                  reasoning_chain=reasoning_chain,
+                  policy=policy,
+                  candidate_diff_generated=candidate_diff_generated,
+                  explanation_matches_diff=explanation_matches_diff,
+                  patch_applied=patch_applied,
+                  security_related_patch=security_related_patch,
+              )
+              proposal = {
+                  "proposal_id": proposal_id,
+                  "status": support["proposal_status"],
+                  "proposal_status": support["proposal_status"],
+                  "proposal_kind": support["proposal_kind"],
+                  "review_route": "HITL_REQUIRED"
+                  if str(entry.get("decision")) == "HITL_REQUIRED"
+                  else "HUMAN_REVIEW_REQUIRED",
+                  "source_entry": source_entry,
+                  "human_readable_explanation": human_readable_explanation,
+                  "evidence": evidence_payload,
+                  "impact_analysis": impact_analysis,
+                  "candidate_patch": candidate_patch,
+                  "validation_plan": validation_plan,
+                  "validation_results": validation_results,
+                  "reasoning_chain": reasoning_chain,
+                  "patch_accountability": {
+                      "patch_generated": True,
+                      "patch_proposal_generated": True,
+                      "patch_applied": patch_applied,
+                      "security_related_patch": security_related_patch,
+                      "has_human_readable_explanation": support["has_human_readable_explanation"],
+                      "has_evidence": support["has_evidence"],
+                      "has_impact_analysis": support["has_impact_analysis"],
+                      "has_validation_plan": support["has_validation_plan"],
+                      "has_validation_results": support["has_validation_results"],
+                      "has_validation_support": support["has_validation_support"],
+                      "reasoning_chain_complete": support["reasoning_chain_complete"],
+                      "explanation_matches_proposal": support["explanation_matches_proposal"],
+                      "explanation_matches_diff": explanation_matches_diff,
+                      "diff_match_status": "not_applicable",
+                      "candidate_diff_generated": candidate_diff_generated,
+                      "support_complete": support["is_supported"],
+                      "auto_patch_application_requested": False,
+                      "auto_commit_requested": False,
+                      "auto_push_requested": False,
+                      "auto_pr_requested": False,
+                      "auto_merge_requested": False,
+                      "auto_deploy_requested": False,
+                      "reason_codes": support["reason_codes"],
+                      "invalid_reason_codes": support["invalid_reason_codes"],
+                  },
+                  "policy": policy,
+              }
+              return proposal
+
+          def attach_explainable_patch_integrity(records: list[dict[str, Any]]) -> dict[str, Any]:
+              previous_hash = ""
+              for record in records:
+                  source_entry = record.get("source_entry", {})
+                  evidence = record.get("evidence", {})
+                  explanation = record.get("human_readable_explanation", {})
+                  proposed_fix = record.get("candidate_patch", {})
+                  impact_analysis = record.get("impact_analysis", {})
+                  validation = {
+                      "validation_plan": record.get("validation_plan", []),
+                      "validation_results": record.get("validation_results", []),
+                  }
+                  policy = record.get("policy", {})
+                  core_record = {
+                      key: value
+                      for key, value in record.items()
+                      if key not in {"integrity"}
+                  }
+                  proposal_hash = canonical_hash(core_record)
+                  integrity = {
+                      "source_entry_hash": canonical_hash(source_entry),
+                      "evidence_hash": canonical_hash(evidence),
+                      "explanation_hash": canonical_hash(explanation),
+                      "proposed_fix_hash": canonical_hash(proposed_fix),
+                      "impact_analysis_hash": canonical_hash(impact_analysis),
+                      "validation_hash": canonical_hash(validation),
+                      "policy_hash": canonical_hash(policy),
+                      "proposal_hash": proposal_hash,
+                      "previous_hash": previous_hash,
+                      "chain_hash": canonical_hash(
+                          {
+                              "previous_hash": previous_hash,
+                              "proposal_hash": proposal_hash,
+                          }
+                      ),
+                  }
+                  record["proposal_hash"] = proposal_hash
+                  record["integrity"] = integrity
+                  previous_hash = integrity["chain_hash"]
+              return {
+                  "hash_chain_verified": True,
+                  "head_hash": previous_hash,
+                  "record_count": len(records),
+              }
+
+          def verify_explainable_patch_hash_chain(records: list[dict[str, Any]]) -> dict[str, Any]:
+              previous_hash = ""
+              errors: list[dict[str, Any]] = []
+              for index, record in enumerate(records, start=1):
+                  integrity = record.get("integrity", {})
+                  if not isinstance(integrity, dict):
+                      errors.append({"index": index, "reason": "integrity_missing"})
+                      integrity = {}
+                  source_entry = record.get("source_entry", {})
+                  evidence = record.get("evidence", {})
+                  explanation = record.get("human_readable_explanation", {})
+                  proposed_fix = record.get("candidate_patch", {})
+                  impact_analysis = record.get("impact_analysis", {})
+                  validation = {
+                      "validation_plan": record.get("validation_plan", []),
+                      "validation_results": record.get("validation_results", []),
+                  }
+                  policy = record.get("policy", {})
+                  core_record = {
+                      key: value
+                      for key, value in record.items()
+                      if key not in {"integrity", "proposal_hash"}
+                  }
+                  expected = {
+                      "source_entry_hash": canonical_hash(source_entry),
+                      "evidence_hash": canonical_hash(evidence),
+                      "explanation_hash": canonical_hash(explanation),
+                      "proposed_fix_hash": canonical_hash(proposed_fix),
+                      "impact_analysis_hash": canonical_hash(impact_analysis),
+                      "validation_hash": canonical_hash(validation),
+                      "policy_hash": canonical_hash(policy),
+                      "proposal_hash": canonical_hash(core_record),
+                      "previous_hash": previous_hash,
+                  }
+                  expected["chain_hash"] = canonical_hash(
+                      {
+                          "previous_hash": previous_hash,
+                          "proposal_hash": expected["proposal_hash"],
+                      }
+                  )
+                  for field, expected_value in expected.items():
+                      actual_value = integrity.get(field)
+                      if actual_value != expected_value:
+                          errors.append(
+                              {
+                                  "index": index,
+                                  "proposal_id": record.get("proposal_id"),
+                                  "field": field,
+                                  "reason": "hash_chain_mismatch",
+                                  "expected": expected_value,
+                                  "actual": actual_value,
+                              }
+                          )
+                  if record.get("proposal_hash") != expected["proposal_hash"]:
+                      errors.append(
+                          {
+                              "index": index,
+                              "proposal_id": record.get("proposal_id"),
+                              "field": "proposal_hash",
+                              "reason": "proposal_hash_field_mismatch",
+                              "expected": expected["proposal_hash"],
+                              "actual": record.get("proposal_hash"),
+                          }
+                      )
+                  previous_hash = str(integrity.get("chain_hash") or expected["chain_hash"])
+              return {
+                  "hash_chain_verified": not errors,
+                  "head_hash": previous_hash,
+                  "record_count": len(records),
+                  "errors": errors,
+              }
+
+          def generate_tasukeru_explainable_patch_proposals(
+              entries: list[dict[str, Any]],
+              state: dict[str, Any],
+              metadata: dict[str, Any],
+          ) -> dict[str, Any]:
+              eligible_decisions = {"HITL_REQUIRED", "FIX_RECOMMENDED", "REVIEW_RECOMMENDED"}
+              priority = {"HITL_REQUIRED": 0, "FIX_RECOMMENDED": 1, "REVIEW_RECOMMENDED": 2}
+              eligible_candidates = [
+                  entry
+                  for entry in entries
+                  if str(entry.get("decision")) in eligible_decisions
+                  and (entry.get("suggestion") or entry.get("message"))
+              ]
+              eligible_candidates = sorted(
+                  eligible_candidates,
+                  key=lambda entry: (
+                      priority.get(str(entry.get("decision")), 99),
+                      str(entry.get("file", "")),
+                      int(entry.get("line") or 0),
+                      str(entry.get("reason_code", "")),
+                  ),
+              )
+              candidate_records = [
+                  build_explainable_patch_candidate(entry, index)
+                  for index, entry in enumerate(eligible_candidates[:120], start=1)
+              ]
+              integrity_summary = attach_explainable_patch_integrity(candidate_records)
+              hash_chain_verify = verify_explainable_patch_hash_chain(candidate_records)
+              valid_proposals = [
+                  record
+                  for record in candidate_records
+                  if record.get("proposal_status") == "EVIDENCE_BACKED_DRAFT_FIX"
+              ]
+              invalid_candidates = [
+                  record
+                  for record in candidate_records
+                  if record.get("proposal_status") == "INVALID_DRAFT_FIX_ERROR"
+              ]
+              invalid_in_valid_count = sum(
+                  1
+                  for record in valid_proposals
+                  if record.get("proposal_status") != "EVIDENCE_BACKED_DRAFT_FIX"
+              )
+              decision_counts = Counter(
+                  str(record.get("source_entry", {}).get("decision", "UNKNOWN"))
+                  for record in candidate_records
+              )
+              route_counts = Counter(str(record.get("review_route", "UNKNOWN")) for record in candidate_records)
+              reason_code_counts = Counter(
+                  reason_code
+                  for record in candidate_records
+                  for reason_code in record.get("patch_accountability", {}).get("reason_codes", [])
+              )
+              invalid_reason_code_counts = Counter(
+                  reason_code
+                  for record in invalid_candidates
+                  for reason_code in record.get("patch_accountability", {}).get("invalid_reason_codes", [])
+              )
+              auto_apply_allowed_all_false = all(
+                  record.get("policy", {}).get("auto_apply_allowed") is False for record in candidate_records
+              )
+              auto_commit_allowed_all_false = all(
+                  record.get("policy", {}).get("auto_commit_allowed") is False for record in candidate_records
+              )
+              auto_push_allowed_all_false = all(
+                  record.get("policy", {}).get("auto_push_allowed") is False for record in candidate_records
+              )
+              auto_pr_creation_allowed_all_false = all(
+                  record.get("policy", {}).get("auto_pr_creation_allowed") is False for record in candidate_records
+              )
+              auto_merge_allowed_all_false = all(
+                  record.get("policy", {}).get("auto_merge_allowed") is False for record in candidate_records
+              )
+              auto_deploy_allowed_all_false = all(
+                  record.get("policy", {}).get("auto_deploy_allowed") is False for record in candidate_records
+              )
+              human_decision_required_all_true = all(
+                  record.get("policy", {}).get("human_decision_required") is True for record in candidate_records
+              )
+              policy_verified = all(
+                  [
+                      auto_apply_allowed_all_false,
+                      auto_commit_allowed_all_false,
+                      auto_push_allowed_all_false,
+                      auto_pr_creation_allowed_all_false,
+                      auto_merge_allowed_all_false,
+                      auto_deploy_allowed_all_false,
+                      human_decision_required_all_true,
+                  ]
+              )
+              support_complete_count = len(valid_proposals)
+              support_incomplete_count = len(invalid_candidates)
+              valid_proposal_count = len(valid_proposals)
+              invalid_draft_fix_error_count = len(invalid_candidates)
+              payload = {
+                  "schema_version": "tasukeru-explainable-patch-proposals-v0.2",
+                  "tool": "tasukeru_explainable_patch_proposal_generator",
+                  "inspired_by": "v0.8 Explainable Patch Gate draft",
+                  "status": "ADVISORY_ONLY_DRAFT",
+                  "generated": True,
+                  "policy_rule": (
+                      "A fix proposal that cannot explain why this fix follows from this evidence "
+                      "is not a valid proposal."
+                  ),
+                  "purpose": (
+                      "Generate evidence-backed, human-readable, unapplied remediation proposals "
+                      "from Tasukeru advisory findings."
+                  ),
+                  "counts": {
+                      "total_candidates": len(candidate_records),
+                      "eligible_finding_count": len(eligible_candidates),
+                      "truncated": len(eligible_candidates) > len(candidate_records),
+                      "proposal_count": valid_proposal_count,
+                      "valid_proposal_count": valid_proposal_count,
+                      "invalid_draft_fix_error_count": invalid_draft_fix_error_count,
+                      "decision_counts": dict(decision_counts),
+                      "review_route_counts": dict(route_counts),
+                      "patch_accountability_reason_code_counts": dict(reason_code_counts),
+                      "invalid_reason_code_counts": dict(invalid_reason_code_counts),
+                      "support_complete_count": support_complete_count,
+                      "support_incomplete_count": support_incomplete_count,
+                      "invalid_in_valid_count": invalid_in_valid_count,
+                  },
+                  "hash_chain": integrity_summary | {
+                      "hash_chain_verified": hash_chain_verify["hash_chain_verified"],
+                      "verification_error_count": len(hash_chain_verify.get("errors", [])),
+                  },
+                  "source_state": {
+                      "critical_count": state.get("critical_count"),
+                      "new_critical_incident_count": state.get("new_critical_incident_count"),
+                  },
+                  "metadata": {
+                      "ruff_count": metadata.get("ruff_count"),
+                      "bandit_count": metadata.get("bandit_count"),
+                      "pip_count": metadata.get("pip_count"),
+                      "logic_count": metadata.get("logic_count"),
+                      "documentation_count": metadata.get("documentation_count"),
+                      "self_definition_count": metadata.get("self_definition_count"),
+                  },
+                  "policy": {
+                      "patches_are_unapplied": True,
+                      "candidate_diffs_are_not_generated": True,
+                      "auto_apply_allowed": False,
+                      "auto_commit_allowed": False,
+                      "auto_push_allowed": False,
+                      "auto_pr_creation_allowed": False,
+                      "auto_merge_allowed": False,
+                      "auto_deploy_allowed": False,
+                      "human_decision_required": True,
+                      "public_comments_must_not_include_payloads": True,
+                      "public_comments_must_not_include_attack_steps": True,
+                  },
+                  "proposals": valid_proposals,
+                  "invalid_draft_fix_errors": invalid_candidates,
+                  "all_candidate_records": candidate_records,
+              }
+              write_json(explainable_patch_proposals_json_path, payload)
+
+              with explainable_patch_proposals_md_path.open("w", encoding="utf-8") as f:
+                  f.write("# Tasukeru Explainable Patch Proposals\n\n")
+                  f.write(
+                      "This artifact is advisory-only. It generates evidence-backed remediation proposals, "
+                      "but does not generate repository diffs, apply fixes, create commits, create PRs, push, deploy, or merge.\n\n"
+                  )
+                  f.write("## Validity rule\n\n")
+                  f.write(
+                      "A fix proposal that cannot explain `why this fix follows from this evidence` "
+                      "is `INVALID_DRAFT_FIX_ERROR`, not `EVIDENCE_BACKED_DRAFT_FIX`.\n\n"
+                  )
+                  f.write("## Counts\n\n")
+                  f.write(f"- Total candidates: `{len(candidate_records)}`\n")
+                  f.write(f"- Valid evidence-backed draft fixes: `{valid_proposal_count}`\n")
+                  f.write(f"- Invalid draft fix errors: `{invalid_draft_fix_error_count}`\n")
+                  f.write(f"- Eligible findings: `{len(eligible_candidates)}`\n")
+                  f.write(f"- Truncated: `{len(eligible_candidates) > len(candidate_records)}`\n")
+                  f.write(f"- Support complete: `{support_complete_count}`\n")
+                  f.write(f"- Support incomplete: `{support_incomplete_count}`\n")
+                  f.write(f"- Hash chain verified: `{hash_chain_verify['hash_chain_verified']}`\n")
+                  f.write("- Auto apply / commit / push / PR / merge / deploy: `false`\n")
+                  f.write("- Human decision required: `true`\n\n")
+
+                  f.write("## Valid Evidence-Backed Draft Fixes\n\n")
+                  if not valid_proposals:
+                      f.write("No valid evidence-backed draft fixes were generated.\n")
+                  for proposal in valid_proposals[:80]:
+                      source = proposal.get("source_entry", {})
+                      location = source.get("file") or "repository"
+                      if source.get("line"):
+                          location = f"{location}:{source.get('line')}"
+                      accountability = proposal.get("patch_accountability", {})
+                      explanation = proposal.get("human_readable_explanation", {})
+                      impact = proposal.get("impact_analysis", {})
+                      integrity = proposal.get("integrity", {})
+                      f.write(
+                          f"- **{proposal.get('proposal_status')}** `{proposal.get('proposal_id')}` "
+                          f"`{source.get('reason_code')}` at `{location}`\n"
+                      )
+                      f.write(f"  - Kind: `{proposal.get('proposal_kind')}` / Route: `{proposal.get('review_route')}`\n")
+                      f.write(f"  - Suggested action: {one_line(explanation.get('summary_ja', ''), 300)}\n")
+                      f.write(f"  - Evidence: {one_line(proposal.get('evidence', {}).get('message', ''), 300)}\n")
+                      f.write(f"  - Expected effect: {one_line(impact.get('expected_effect_ja', ''), 300)}\n")
+                      f.write(
+                          "  - Accountability: "
+                          f"explanation_matches_proposal=`{accountability.get('explanation_matches_proposal')}`, "
+                          f"diff_match_status=`{accountability.get('diff_match_status')}`\n"
+                      )
+                      f.write(f"  - Reason codes: `{accountability.get('reason_codes')}`\n")
+                      f.write(f"  - Chain hash: `{integrity.get('chain_hash')}`\n")
+                  if len(valid_proposals) > 80:
+                      f.write(
+                          f"\n... and {len(valid_proposals) - 80} more valid proposals in "
+                          "`tasukeru_explainable_patch_proposals.json`.\n"
+                      )
+
+                  f.write("\n## Invalid Draft Fix Errors\n\n")
+                  if not invalid_candidates:
+                      f.write("No invalid draft fix errors were produced.\n")
+                  for proposal in invalid_candidates[:80]:
+                      source = proposal.get("source_entry", {})
+                      location = source.get("file") or "repository"
+                      if source.get("line"):
+                          location = f"{location}:{source.get('line')}"
+                      accountability = proposal.get("patch_accountability", {})
+                      f.write(
+                          f"- **INVALID_DRAFT_FIX_ERROR** `{proposal.get('proposal_id')}` "
+                          f"`{source.get('reason_code')}` at `{location}`\n"
+                      )
+                      f.write(f"  - Rejected reason codes: `{accountability.get('invalid_reason_codes')}`\n")
+                      f.write(f"  - All reason codes: `{accountability.get('reason_codes')}`\n")
+                      f.write(f"  - Kind: `{proposal.get('proposal_kind')}`\n")
+                  if len(invalid_candidates) > 80:
+                      f.write(
+                          f"\n... and {len(invalid_candidates) - 80} more invalid candidates in "
+                          "`tasukeru_explainable_patch_proposals.json`.\n"
+                      )
+
+              verify_payload = {
+                  "schema_version": "tasukeru-explainable-patch-proposals-verify-v0.2",
+                  "verified": policy_verified
+                  and hash_chain_verify["hash_chain_verified"]
+                  and invalid_in_valid_count == 0
+                  and explainable_patch_proposals_json_path.exists()
+                  and explainable_patch_proposals_md_path.exists(),
+                  "total_candidates": len(candidate_records),
+                  "proposal_count": valid_proposal_count,
+                  "valid_proposal_count": valid_proposal_count,
+                  "invalid_draft_fix_error_count": invalid_draft_fix_error_count,
+                  "support_complete_count": support_complete_count,
+                  "support_incomplete_count": support_incomplete_count,
+                  "invalid_reason_code_counts": dict(invalid_reason_code_counts),
+                  "invalid_in_valid_count": invalid_in_valid_count,
+                  "hash_chain_verified": hash_chain_verify["hash_chain_verified"],
+                  "hash_chain_head": hash_chain_verify["head_hash"],
+                  "hash_chain_error_count": len(hash_chain_verify.get("errors", [])),
+                  "hash_chain_errors": hash_chain_verify.get("errors", [])[:50],
+                  "policy_verified": policy_verified,
+                  "auto_apply_allowed_all_false": auto_apply_allowed_all_false,
+                  "auto_commit_allowed_all_false": auto_commit_allowed_all_false,
+                  "auto_push_allowed_all_false": auto_push_allowed_all_false,
+                  "auto_pr_creation_allowed_all_false": auto_pr_creation_allowed_all_false,
+                  "auto_merge_allowed_all_false": auto_merge_allowed_all_false,
+                  "auto_deploy_allowed_all_false": auto_deploy_allowed_all_false,
+                  "human_decision_required_all_true": human_decision_required_all_true,
+                  "auto_apply_allowed": False,
+                  "auto_commit_allowed": False,
+                  "auto_push_allowed": False,
+                  "auto_pr_creation_allowed": False,
+                  "auto_merge_allowed": False,
+                  "auto_deploy_allowed": False,
+                  "human_decision_required": True,
+                  "json_artifact": str(explainable_patch_proposals_json_path),
+                  "md_artifact": str(explainable_patch_proposals_md_path),
+                  "json_sha256": sha256_file(explainable_patch_proposals_json_path)
+                  if explainable_patch_proposals_json_path.exists()
+                  else "",
+                  "md_sha256": sha256_file(explainable_patch_proposals_md_path)
+                  if explainable_patch_proposals_md_path.exists()
+                  else "",
+              }
+              write_json(explainable_patch_proposals_verify_path, verify_payload)
+
+              return {
+                  "schema_version": payload["schema_version"],
+                  "generated": True,
+                  "verified": verify_payload["verified"],
+                  "total_candidates": len(candidate_records),
+                  "proposal_count": valid_proposal_count,
+                  "valid_proposal_count": valid_proposal_count,
+                  "invalid_draft_fix_error_count": invalid_draft_fix_error_count,
+                  "support_complete_count": support_complete_count,
+                  "support_incomplete_count": support_incomplete_count,
+                  "hash_chain_verified": hash_chain_verify["hash_chain_verified"],
+                  "artifacts": [
+                      str(explainable_patch_proposals_md_path),
+                      str(explainable_patch_proposals_json_path),
+                      str(explainable_patch_proposals_verify_path),
+                  ],
+              }
+
           def make_unified_diff(
               *,
               file_path: str,
@@ -3803,6 +4696,9 @@ jobs:
                   probabilistic_escalation_md_path,
                   probabilistic_escalation_json_path,
                   probabilistic_escalation_verify_path,
+                  explainable_patch_proposals_md_path,
+                  explainable_patch_proposals_json_path,
+                  explainable_patch_proposals_verify_path,
                   log_dir / "logic-review.json",
                   log_dir / "documentation-review.json",
                   log_dir / "ruff.json",
@@ -3942,6 +4838,9 @@ jobs:
                   look_first.append("tasukeru_readme_refinement_draft.md")
               if confidence_report:
                   look_first.append("tasukeru_confidence_report.md")
+              patch_proposals_report = read_json(explainable_patch_proposals_json_path, {})
+              if patch_proposals_report:
+                  look_first.append("tasukeru_explainable_patch_proposals.md")
 
               source_constraints = {
                   "source_of_truth": "tasukeru_arl.jsonl + tasukeru_arl_verify.json + advisory artifacts",
@@ -4624,6 +5523,9 @@ jobs:
                   probabilistic_escalation_md_path,
                   probabilistic_escalation_json_path,
                   probabilistic_escalation_verify_path,
+                  explainable_patch_proposals_md_path,
+                  explainable_patch_proposals_json_path,
+                  explainable_patch_proposals_verify_path,
                   pr_draft_md_path,
                   pr_draft_json_path,
                   pr_draft_verify_path,
@@ -5023,6 +5925,8 @@ jobs:
               probabilistic_escalation_verify_payload = read_json(probabilistic_escalation_verify_path, {})
               trust_boundary_risk_payload = read_json(trust_boundary_risk_json_path, {})
               trust_boundary_risk_verify_payload = read_json(trust_boundary_risk_verify_path, {})
+              explainable_patch_proposals_payload = read_json(explainable_patch_proposals_json_path, {})
+              explainable_patch_proposals_verify_payload = read_json(explainable_patch_proposals_verify_path, {})
               pr_comment_text = read_text(pr_comment_path, "")
 
               # 3D-VAF / SIS / 3D-DAC / PR-comment consistency.
@@ -5031,12 +5935,27 @@ jobs:
               dimension_dependency_metadata = metadata.get("dimension_dependency", {}) if isinstance(metadata, dict) else {}
               probabilistic_escalation_metadata = metadata.get("probabilistic_escalation", {}) if isinstance(metadata, dict) else {}
               trust_boundary_risk_metadata = metadata.get("trust_boundary_risk", {}) if isinstance(metadata, dict) else {}
+              explainable_patch_proposals_metadata = metadata.get("explainable_patch_proposals", {}) if isinstance(metadata, dict) else {}
               three_d_counts = three_d_vaf_payload.get("counts", {}) if isinstance(three_d_vaf_payload, dict) else {}
               sis_counts = sis_payload.get("counts", {}) if isinstance(sis_payload, dict) else {}
               dimension_dependency_counts = dimension_dependency_payload.get("counts", {}) if isinstance(dimension_dependency_payload, dict) else {}
               probabilistic_escalation_counts = probabilistic_escalation_payload.get("counts", {}) if isinstance(probabilistic_escalation_payload, dict) else {}
               probabilistic_escalation_summary = probabilistic_escalation_payload.get("probability_summary", {}) if isinstance(probabilistic_escalation_payload, dict) else {}
               trust_boundary_risk_counts = trust_boundary_risk_payload.get("counts", {}) if isinstance(trust_boundary_risk_payload, dict) else {}
+              explainable_patch_proposals_counts = explainable_patch_proposals_payload.get("counts", {}) if isinstance(explainable_patch_proposals_payload, dict) else {}
+              explainable_patch_hash_chain = explainable_patch_proposals_payload.get("hash_chain", {}) if isinstance(explainable_patch_proposals_payload, dict) else {}
+              explainable_patch_valid_records = explainable_patch_proposals_payload.get("proposals", []) if isinstance(explainable_patch_proposals_payload, dict) else []
+              if not isinstance(explainable_patch_valid_records, list):
+                  explainable_patch_valid_records = []
+              explainable_patch_invalid_records = explainable_patch_proposals_payload.get("invalid_draft_fix_errors", []) if isinstance(explainable_patch_proposals_payload, dict) else []
+              if not isinstance(explainable_patch_invalid_records, list):
+                  explainable_patch_invalid_records = []
+              explainable_patch_invalid_in_valid_count = sum(
+                  1
+                  for item in explainable_patch_valid_records
+                  if isinstance(item, dict)
+                  and item.get("proposal_status") != "EVIDENCE_BACKED_DRAFT_FIX"
+              )
               sis_comment_policy = sis_payload.get("comment_policy", {}) if isinstance(sis_payload, dict) else {}
               sis_overall_risk_level = str(sis_payload.get("overall_risk_level", "UNKNOWN")) if isinstance(sis_payload, dict) else "UNKNOWN"
 
@@ -5255,6 +6174,158 @@ jobs:
                   output_value=bool(trust_boundary_risk_verify_payload.get("changes_existing_decisions", True)),
                   artifact=str(trust_boundary_risk_verify_path),
                   reason_code="RESULT_TBRL_DECISION_MUTATION_POLICY_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.metadata_count",
+                  process_value=int(explainable_patch_proposals_counts.get("proposal_count", -1)),
+                  output_value=int(explainable_patch_proposals_metadata.get("proposal_count", -1)),
+                  artifact=str(explainable_patch_proposals_json_path),
+                  reason_code="RESULT_EPP_METADATA_COUNT_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.valid_count_matches_proposal_count",
+                  process_value=int(explainable_patch_proposals_counts.get("valid_proposal_count", -1)),
+                  output_value=int(explainable_patch_proposals_counts.get("proposal_count", -2)),
+                  artifact=str(explainable_patch_proposals_json_path),
+                  reason_code="RESULT_EPP_VALID_COUNT_PROPOSAL_COUNT_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.metadata_total_candidates",
+                  process_value=int(explainable_patch_proposals_counts.get("total_candidates", -1)),
+                  output_value=int(explainable_patch_proposals_metadata.get("total_candidates", -1)),
+                  artifact=str(explainable_patch_proposals_json_path),
+                  reason_code="RESULT_EPP_METADATA_TOTAL_CANDIDATES_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.metadata_invalid_count",
+                  process_value=int(explainable_patch_proposals_counts.get("invalid_draft_fix_error_count", -1)),
+                  output_value=int(explainable_patch_proposals_metadata.get("invalid_draft_fix_error_count", -1)),
+                  artifact=str(explainable_patch_proposals_json_path),
+                  reason_code="RESULT_EPP_METADATA_INVALID_COUNT_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.verify_count",
+                  process_value=int(explainable_patch_proposals_counts.get("proposal_count", -1)),
+                  output_value=int(explainable_patch_proposals_verify_payload.get("proposal_count", -1)),
+                  artifact=str(explainable_patch_proposals_verify_path),
+                  reason_code="RESULT_EPP_VERIFY_COUNT_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.verify_total_candidates",
+                  process_value=int(explainable_patch_proposals_counts.get("total_candidates", -1)),
+                  output_value=int(explainable_patch_proposals_verify_payload.get("total_candidates", -1)),
+                  artifact=str(explainable_patch_proposals_verify_path),
+                  reason_code="RESULT_EPP_VERIFY_TOTAL_CANDIDATES_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.verify_invalid_count",
+                  process_value=int(explainable_patch_proposals_counts.get("invalid_draft_fix_error_count", -1)),
+                  output_value=int(explainable_patch_proposals_verify_payload.get("invalid_draft_fix_error_count", -1)),
+                  artifact=str(explainable_patch_proposals_verify_path),
+                  reason_code="RESULT_EPP_VERIFY_INVALID_COUNT_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.invalid_not_counted_as_valid",
+                  process_value=0,
+                  output_value=int(explainable_patch_proposals_counts.get("invalid_in_valid_count", -1)),
+                  artifact=str(explainable_patch_proposals_json_path),
+                  reason_code="RESULT_EPP_INVALID_COUNTED_AS_VALID",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.valid_records_status",
+                  process_value=0,
+                  output_value=explainable_patch_invalid_in_valid_count,
+                  artifact=str(explainable_patch_proposals_json_path),
+                  reason_code="RESULT_EPP_INVALID_RECORD_IN_VALID_PROPOSALS",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.invalid_records_count",
+                  process_value=int(explainable_patch_proposals_counts.get("invalid_draft_fix_error_count", -1)),
+                  output_value=len(explainable_patch_invalid_records),
+                  artifact=str(explainable_patch_proposals_json_path),
+                  reason_code="RESULT_EPP_INVALID_RECORD_COUNT_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.hash_chain_verified",
+                  process_value=True,
+                  output_value=bool(explainable_patch_hash_chain.get("hash_chain_verified", False)),
+                  artifact=str(explainable_patch_proposals_json_path),
+                  reason_code="RESULT_EPP_HASH_CHAIN_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.verify_hash_chain_verified",
+                  process_value=True,
+                  output_value=bool(explainable_patch_proposals_verify_payload.get("hash_chain_verified", False)),
+                  artifact=str(explainable_patch_proposals_verify_path),
+                  reason_code="RESULT_EPP_VERIFY_HASH_CHAIN_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.verify_auto_apply_all_false",
+                  process_value=True,
+                  output_value=bool(explainable_patch_proposals_verify_payload.get("auto_apply_allowed_all_false", False)),
+                  artifact=str(explainable_patch_proposals_verify_path),
+                  reason_code="RESULT_EPP_AUTO_APPLY_POLICY_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.verify_auto_commit_all_false",
+                  process_value=True,
+                  output_value=bool(explainable_patch_proposals_verify_payload.get("auto_commit_allowed_all_false", False)),
+                  artifact=str(explainable_patch_proposals_verify_path),
+                  reason_code="RESULT_EPP_AUTO_COMMIT_POLICY_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.verify_auto_push_all_false",
+                  process_value=True,
+                  output_value=bool(explainable_patch_proposals_verify_payload.get("auto_push_allowed_all_false", False)),
+                  artifact=str(explainable_patch_proposals_verify_path),
+                  reason_code="RESULT_EPP_AUTO_PUSH_POLICY_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.verify_auto_pr_all_false",
+                  process_value=True,
+                  output_value=bool(explainable_patch_proposals_verify_payload.get("auto_pr_creation_allowed_all_false", False)),
+                  artifact=str(explainable_patch_proposals_verify_path),
+                  reason_code="RESULT_EPP_AUTO_PR_POLICY_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.verify_auto_merge_all_false",
+                  process_value=True,
+                  output_value=bool(explainable_patch_proposals_verify_payload.get("auto_merge_allowed_all_false", False)),
+                  artifact=str(explainable_patch_proposals_verify_path),
+                  reason_code="RESULT_EPP_AUTO_MERGE_POLICY_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.verify_auto_deploy_all_false",
+                  process_value=True,
+                  output_value=bool(explainable_patch_proposals_verify_payload.get("auto_deploy_allowed_all_false", False)),
+                  artifact=str(explainable_patch_proposals_verify_path),
+                  reason_code="RESULT_EPP_AUTO_DEPLOY_POLICY_MISMATCH",
+              )
+              compare_result_field(
+                  mismatches,
+                  field="explainable_patch_proposals.verify_human_decision_required_all_true",
+                  process_value=True,
+                  output_value=bool(explainable_patch_proposals_verify_payload.get("human_decision_required_all_true", False)),
+                  artifact=str(explainable_patch_proposals_verify_path),
+                  reason_code="RESULT_EPP_HUMAN_DECISION_POLICY_MISMATCH",
               )
 
               # Public-comment consistency is intentionally coarse: the comment must
@@ -5587,6 +6658,9 @@ jobs:
                       str(probabilistic_escalation_md_path),
                       str(probabilistic_escalation_json_path),
                       str(probabilistic_escalation_verify_path),
+                      str(explainable_patch_proposals_md_path),
+                      str(explainable_patch_proposals_json_path),
+                      str(explainable_patch_proposals_verify_path),
                       str(pr_comment_path),
                   ],
                   "process_counts": normalized_counts,
@@ -7303,6 +8377,7 @@ jobs:
                           "No file is automatically modified. Auto-merge is prohibited."
                       ),
                   },
+                  "explainable_patch_proposals": metadata.get("explainable_patch_proposals", {}),
                   "entries": entries,
               }
               write_json(hitl_json_path, payload)
@@ -7340,6 +8415,20 @@ jobs:
                   f.write("- Auto fix: false\n")
                   f.write("- Auto merge: false\n")
                   f.write("- Rule: safe candidates are manual decision-support metadata only.\n\n")
+                  patch_proposals = metadata.get("explainable_patch_proposals", {})
+                  if isinstance(patch_proposals, dict):
+                      f.write("## Explainable patch proposals\n\n")
+                      f.write(f"- Generated: `{patch_proposals.get('generated')}`\n")
+                      f.write(f"- Verified: `{patch_proposals.get('verified')}`\n")
+                      f.write(f"- Proposal count: `{patch_proposals.get('proposal_count')}`\n")
+                      f.write(f"- Total candidates: `{patch_proposals.get('total_candidates')}`\n")
+                      f.write(f"- Valid proposals: `{patch_proposals.get('valid_proposal_count')}`\n")
+                      f.write(f"- Invalid draft fix errors: `{patch_proposals.get('invalid_draft_fix_error_count')}`\n")
+                      f.write(f"- Support complete: `{patch_proposals.get('support_complete_count')}`\n")
+                      f.write(f"- Support incomplete: `{patch_proposals.get('support_incomplete_count')}`\n")
+                      f.write(f"- Hash chain verified: `{patch_proposals.get('hash_chain_verified')}`\n")
+                      f.write("- Artifact: `tasukeru_explainable_patch_proposals.md` / `tasukeru_explainable_patch_proposals.json`\n")
+                      f.write("- Auto apply: false\n\n")
                   f.write("## Priority review queue\n\n")
                   if priority:
                       for entry in priority[:80]:
@@ -7393,6 +8482,9 @@ jobs:
                   f.write("- `tasukeru_confidence_report.json`\n")
                   f.write("- `tasukeru_readme_refinement_draft.md`\n")
                   f.write("- `tasukeru_readme_refinement_draft.json`\n")
+                  f.write("- `tasukeru_explainable_patch_proposals.md`\n")
+                  f.write("- `tasukeru_explainable_patch_proposals.json`\n")
+                  f.write("- `tasukeru_explainable_patch_proposals_verify.json`\n")
                   f.write("- `tasukeru_announcement.md`\n")
                   f.write("- `tasukeru_announcement.json`\n")
                   f.write("- `tasukeru_3d_vulnerability_review.md`\n")
@@ -7582,6 +8674,12 @@ jobs:
               metadata,
           )
           metadata["finding_validation"] = finding_validation_result
+          explainable_patch_proposals_result = generate_tasukeru_explainable_patch_proposals(
+              all_entries,
+              notification_state,
+              metadata,
+          )
+          metadata["explainable_patch_proposals"] = explainable_patch_proposals_result
 
           write_outputs(all_entries, notification_state, metadata)
           generate_dradm_draft_artifacts(all_entries, notification_state, metadata)
@@ -7765,6 +8863,14 @@ jobs:
           print(f"PEL escalation candidates: {pel.get('escalation_candidate_count')}")
           print(f"PEL mandatory HITL: {pel.get('mandatory_hitl_count')}")
           print(f"PEL max probability: {pel.get('max_probability')}")
+          print("")
+          print("Explainable Patch Proposals v0.1")
+          patch_proposals = metadata.get("explainable_patch_proposals", {})
+          print(f"Patch proposal count: {patch_proposals.get('proposal_count')}")
+          print(f"Patch total candidates: {patch_proposals.get('total_candidates')}")
+          print(f"Patch invalid draft fix errors: {patch_proposals.get('invalid_draft_fix_error_count')}")
+          print(f"Patch hash chain verified: {patch_proposals.get('hash_chain_verified')}")
+          print(f"Patch proposals verified: {patch_proposals.get('verified')}")
           print("")
 
           print("3D Dimension Dependency Audit v0.1")
@@ -9486,6 +10592,9 @@ jobs:
             tasukeru_confidence_report.json
             tasukeru_readme_refinement_draft.md
             tasukeru_readme_refinement_draft.json
+            tasukeru_explainable_patch_proposals.md
+            tasukeru_explainable_patch_proposals.json
+            tasukeru_explainable_patch_proposals_verify.json
             tasukeru_announcement.md
             tasukeru_announcement.json
             tasukeru_3d_vulnerability_review.md


### PR DESCRIPTION
- Separate EVIDENCE_BACKED_DRAFT_FIX from INVALID_DRAFT_FIX_ERROR
- Require evidence, explanation, impact analysis, validation support, and reasoning-chain checks before counting a proposal as valid
- Keep invalid candidates out of valid proposals
- Add proposal hash-chain metadata and verification fields
- Keep the workflow advisory-only with auto-apply, commit, push, PR creation, merge, and deploy disabled
- Preserve HITL requirements and do not change 4D / Memory / Session / Checkpoint behavior