### PR TITLE
Patch 2 minimal workflow integration

### DIFF
--- a/.github/workflows/tasukeru-analysis.yml
+++ b/.github/workflows/tasukeru-analysis.yml
@@ -396,6 +396,47 @@ jobs:
           echo "bandit_exit=${bandit_exit}"
           echo "pip_exit=${pip_exit}"
 
+      - name: Validate explainable patch proposal gate
+        if: always()
+        run: |
+          set -euo pipefail
+          python -m py_compile scripts/tasukeru_explainable_patch.py
+          python -m py_compile tests/test_tasukeru_explainable_patch.py
+          if python -c "import pytest" >/dev/null 2>&1; then
+            python -m pytest tests/test_tasukeru_explainable_patch.py -q
+          else
+            echo "pytest is not installed; skipped explainable patch proposal tests."
+          fi
+
+      - name: Generate explainable patch proposal artifacts
+        if: always()
+        run: |
+          set -euo pipefail
+          out_dir="tasukeru_logs/explainable_patch_proposals"
+          input_path="$out_dir/candidates.json"
+          mkdir -p "$out_dir"
+          cat > "$input_path" <<'JSON'
+          {
+            "safety_metadata": {
+              "human_review_required": true,
+              "automatic_apply": false,
+              "automatic_commit": false,
+              "automatic_push": false,
+              "automatic_pr": false,
+              "automatic_merge": false,
+              "automatic_deploy": false,
+              "ai_api_call": false,
+              "api_key_required": false,
+              "external_ai_provider": null,
+              "billable_action": false
+            },
+            "candidates": []
+          }
+          JSON
+          python scripts/tasukeru_explainable_patch.py \
+            --input "$input_path" \
+            --out-dir "$out_dir"
+
       - name: Generate Tasukeru advisory review
         if: always()
         run: |
@@ -9537,6 +9578,14 @@ jobs:
             tasukeru_arl.jsonl
             tasukeru_arl_verify.json
           if-no-files-found: ignore
+
+      - name: Upload explainable patch proposal artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: tasukeru-explainable-patch-proposals
+          path: tasukeru_logs/explainable_patch_proposals/
+          if-no-files-found: warn
 
       - name: Complete advisory phase
         if: always()

--- a/scripts/tasukeru_explainable_patch.py
+++ b/scripts/tasukeru_explainable_patch.py
@@ -51,6 +51,20 @@ BLOCKED_AUTOMATION_REASON_CODES = (
     AUTOMATIC_DEPLOY_BLOCKED,
 )
 
+PROJECT_BOUNDARY_SAFETY_METADATA = {
+    "human_review_required": True,
+    "automatic_apply": False,
+    "automatic_commit": False,
+    "automatic_push": False,
+    "automatic_pr": False,
+    "automatic_merge": False,
+    "automatic_deploy": False,
+    "ai_api_call": False,
+    "api_key_required": False,
+    "external_ai_provider": None,
+    "billable_action": False,
+}
+
 REASONING_CHAIN_FIELDS = (
     "observed_issue",
     "evidence",
@@ -100,6 +114,10 @@ def support_text(value: Any) -> str:
 
 def unique_reason_codes(reason_codes: list[str]) -> list[str]:
     return list(dict.fromkeys(reason_codes))
+
+
+def safety_metadata() -> dict[str, Any]:
+    return dict(PROJECT_BOUNDARY_SAFETY_METADATA)
 
 
 def as_bool(value: Any, default: bool = False) -> bool:
@@ -627,6 +645,7 @@ def build_payload(candidates: list[dict[str, Any]]) -> dict[str, Any]:
             "A fix proposal that cannot explain why this fix follows from this "
             "evidence is not a valid proposal."
         ),
+        "safety_metadata": safety_metadata(),
         "counts": {
             "total_candidates": len(records),
             "proposal_count": len(valid),
@@ -666,10 +685,25 @@ def write_json(path: Path, payload: Any) -> None:
 
 
 def write_markdown(path: Path, payload: dict[str, Any]) -> None:
+    safety = payload["safety_metadata"]
     lines = [
         "# Tasukeru Explainable Patch Proposals",
         "",
         "This artifact is advisory-only. It does not apply fixes, commit, push, create PRs, merge, or deploy.",
+        "",
+        "## Safety Boundary",
+        "",
+        f"- Human review required: `{json.dumps(safety['human_review_required'])}`",
+        f"- Automatic apply: `{json.dumps(safety['automatic_apply'])}`",
+        f"- Automatic commit: `{json.dumps(safety['automatic_commit'])}`",
+        f"- Automatic push: `{json.dumps(safety['automatic_push'])}`",
+        f"- Automatic PR: `{json.dumps(safety['automatic_pr'])}`",
+        f"- Automatic merge: `{json.dumps(safety['automatic_merge'])}`",
+        f"- Automatic deploy: `{json.dumps(safety['automatic_deploy'])}`",
+        f"- AI API call: `{json.dumps(safety['ai_api_call'])}`",
+        f"- API key required: `{json.dumps(safety['api_key_required'])}`",
+        f"- External AI provider: `{json.dumps(safety['external_ai_provider'])}`",
+        f"- Billable action: `{json.dumps(safety['billable_action'])}`",
         "",
         "## Counts",
         "",
@@ -738,6 +772,7 @@ def write_artifacts(candidates: list[dict[str, Any]], output_dir: Path) -> dict[
         "invalid_in_valid_count": payload["counts"]["invalid_in_valid_count"],
         "policy_verification": payload["policy"],
         "hash_chain_verification": payload["hash_chain"],
+        "safety_metadata": payload["safety_metadata"],
         "hash_chain_note": (
             "Verifies internal chain consistency. Authenticity requires preserving "
             "or comparing the head hash externally."

--- a/tests/test_tasukeru_explainable_patch.py
+++ b/tests/test_tasukeru_explainable_patch.py
@@ -11,6 +11,21 @@ sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 import tasukeru_explainable_patch as epp  # noqa: E402
 
 
+EXPECTED_SAFETY_METADATA = {
+    "human_review_required": True,
+    "automatic_apply": False,
+    "automatic_commit": False,
+    "automatic_push": False,
+    "automatic_pr": False,
+    "automatic_merge": False,
+    "automatic_deploy": False,
+    "ai_api_call": False,
+    "api_key_required": False,
+    "external_ai_provider": None,
+    "billable_action": False,
+}
+
+
 def valid_candidate(**overrides):
     candidate = {
         "observed_issue": "Ruff F401 observed an unused import.",
@@ -53,11 +68,22 @@ def test_as_bool_unknown_string_returns_default():
     assert epp.as_bool("maybe", default=True) is True
 
 
+def test_safety_metadata_matches_project_boundary():
+    assert epp.safety_metadata() == EXPECTED_SAFETY_METADATA
+
+
+def test_build_payload_includes_safety_metadata():
+    payload = epp.build_payload([valid_candidate()])
+
+    assert payload["safety_metadata"] == EXPECTED_SAFETY_METADATA
+
+
 def test_valid_manual_outline_is_evidence_backed_but_not_diff_validated():
     payload, record = build_one(valid_candidate())
 
     assert payload["counts"]["valid_proposal_count"] == 1
     assert payload["counts"]["invalid_draft_fix_error_count"] == 0
+    assert payload["safety_metadata"] == EXPECTED_SAFETY_METADATA
     assert record["proposal_status"] == epp.VALID_STATUS
     assert record["proposal_kind"] == epp.MANUAL_OUTLINE
     assert record["candidate_patch"]["candidate_diff_generated"] is False
@@ -219,7 +245,7 @@ def test_hash_chain_verification_detects_tampering():
     assert verification["errors"]
 
 
-def test_write_artifacts_reports_counts_policy_hash_and_existence(tmp_path):
+def test_write_artifacts_reports_counts_policy_hash_existence_and_safety(tmp_path):
     result = epp.write_artifacts(
         [
             valid_candidate(),
@@ -238,6 +264,7 @@ def test_write_artifacts_reports_counts_policy_hash_and_existence(tmp_path):
     assert verify["verified"] is True
     assert verify["policy_verification"]["policy_verified"] is True
     assert verify["hash_chain_verification"]["hash_chain_verified"] is True
+    assert verify["safety_metadata"] == EXPECTED_SAFETY_METADATA
     assert verify["hash_chain_note"] == (
         "Verifies internal chain consistency. Authenticity requires preserving "
         "or comparing the head hash externally."
@@ -251,6 +278,17 @@ def test_write_artifacts_reports_counts_policy_hash_and_existence(tmp_path):
     data = json.loads(result["json_path"].read_text(encoding="utf-8"))
     assert data["counts"]["valid_proposal_count"] == 1
     assert data["counts"]["invalid_draft_fix_error_count"] == 1
+    assert data["safety_metadata"] == EXPECTED_SAFETY_METADATA
+
+    markdown = result["markdown_path"].read_text(encoding="utf-8")
+    assert "## Safety Boundary" in markdown
+    assert "AI API call" in markdown
+    assert "API key required" in markdown
+    assert "Billable action" in markdown
+    assert "- AI API call: `false`" in markdown
+    assert "- API key required: `false`" in markdown
+    assert "- External AI provider: `null`" in markdown
+    assert "- Billable action: `false`" in markdown
 
 
 def test_cli_smoke_writes_artifacts_and_verified_true(tmp_path):
@@ -268,8 +306,45 @@ def test_cli_smoke_writes_artifacts_and_verified_true(tmp_path):
 
     verify = json.loads(verify_path.read_text(encoding="utf-8"))
     assert verify["verified"] is True
+    assert verify["safety_metadata"] == EXPECTED_SAFETY_METADATA
     assert verify["output_existence_checks"] == {
         "json": True,
         "markdown": True,
         "verify": True,
     }
+
+
+def test_cli_smoke_accepts_workflow_empty_candidate_input(tmp_path):
+    input_path = tmp_path / "workflow-candidates.json"
+    input_path.write_text(
+        json.dumps(
+            {
+                "safety_metadata": EXPECTED_SAFETY_METADATA,
+                "candidates": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert epp.main(["--input", str(input_path), "--out-dir", str(tmp_path)]) == 0
+
+    json_path = tmp_path / "tasukeru_explainable_patch_proposals.json"
+    markdown_path = tmp_path / "tasukeru_explainable_patch_proposals.md"
+    verify_path = tmp_path / "tasukeru_explainable_patch_proposals_verify.json"
+    assert json_path.exists()
+    assert markdown_path.exists()
+    assert verify_path.exists()
+
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    verify = json.loads(verify_path.read_text(encoding="utf-8"))
+    markdown = markdown_path.read_text(encoding="utf-8")
+
+    assert payload["safety_metadata"] == EXPECTED_SAFETY_METADATA
+    assert verify["verified"] is True
+    assert verify["valid_proposal_count"] == 0
+    assert verify["invalid_candidate_count"] == 0
+    assert verify["safety_metadata"] == EXPECTED_SAFETY_METADATA
+    assert "## Safety Boundary" in markdown
+    assert "AI API call" in markdown
+    assert "API key required" in markdown
+    assert "Billable action" in markdown


### PR DESCRIPTION
## Summary

Implements Patch 2 minimal workflow integration.

- Adds project boundary safety metadata to explainable patch JSON, Markdown, and verify artifacts.
- Adds tests for safety metadata output and workflow-shaped empty candidate input.
- Adds thin workflow steps to validate and generate explainable patch proposal artifacts.
- Adds dedicated artifact upload: `tasukeru-explainable-patch-proposals`.

## Safety boundary

- No AI API calls.
- No API keys or secrets.
- No external AI provider calls.
- No billable actions.
- No write permissions.
- No automatic apply, commit, push, PR creation, merge, or deploy behavior.
- Patch 3 / Patch 4 / Patch 5 candidate work is not included.

## Remaining risks

- GitHub Actions real runner has not been verified yet.
- `actions/upload-artifact@v6` runner compatibility will be confirmed at workflow runtime.