### PR TITLE
Add Patch 5 pseudo-orchestration release note

### DIFF
--- a/docs/release-notes/patch-5-pseudo-orchestration.md
+++ b/docs/release-notes/patch-5-pseudo-orchestration.md
@@ -1,0 +1,125 @@
+# Patch 5: Pseudo-orchestration specification
+
+## Status
+
+Patch 5 is complete and was merged to `main` via PR #891.
+
+- PR number: #891
+- PR title: Add Patch 5 pseudo-orchestration spec
+- merge commit: 59d5971738bdbb9d83d454ba6f4d69ef5ebf7b6f
+- merged at: 2026-07-05T00:38:28Z
+- merged_to_main: true
+- post_merge_verification: completed
+
+## Summary
+
+Patch 5 added the pseudo-orchestration specification.
+
+The specification defines a dry-run / simulation / fixture-based pseudo-orchestration layer for preparing reviewable materials without calling AI APIs.
+
+Core boundary:
+
+```text
+AI連携っぽい構造は作る。
+しかし、AI連携はしない。
+workflowはAIを呼ばず、AIに渡せる材料を作るだけ。
+```
+
+Patch 5 is documentation/specification only. It does not implement runtime orchestration, model inference, code changes, or workflow behavior.
+
+## Files added / changed
+
+Patch 5 added one specification file:
+
+- `docs/specs/patch-5-pseudo-orchestration.md`
+
+## Scope
+
+Patch 5 scope is limited to:
+
+- dry-run pseudo-orchestration design
+- simulation / fixture-based structure
+- advisory-only artifact design
+- human review boundary documentation
+- automation acceptance criteria documentation
+
+## Non-goals
+
+Patch 5 does not implement real AI integration.
+
+- no AI provider calls
+- no model inference
+- no automated code changes
+- no auto-fix
+- no auto-commit
+- no auto-PR
+- no auto-merge
+- no deploy
+
+## Safety boundary
+
+Patch 5 keeps the project safety boundary intact.
+
+- documentation/spec-only change
+- no workflow changes
+- no script changes
+- no test changes
+- no generated outputs committed
+- no AI API calls
+- no API keys or secrets
+- no GitHub Actions secrets
+- no external AI provider calls
+- no runtime external network calls
+- no billable action
+- no auto-fix
+- no auto-commit-to-main
+- no auto-PR
+- no auto-merge
+- no deploy
+- human review remains required
+
+## Automation acceptance criteria
+
+Patch 5 documents that automation may be considered only when all of the following are true:
+
+- the behavior is explainable
+- the change scope is limited
+- the before and after states are recorded
+- a rollback procedure exists
+- the rollback procedure has been verified
+- execution can stop safely on failure
+
+These criteria are documented only. Patch 5 does not implement automation.
+
+## Workflow boundary
+
+Patch 5 states that GitHub Actions may only generate local artifacts for review.
+
+Workflow steps must not call AI APIs, external AI providers, or runtime external network services for pseudo-orchestration. Workflow permissions must remain read-only for Patch 5 initial scope. Any permission increase is out of scope and requires a separate reviewed patch.
+
+## Verification
+
+Patch 5 was verified as follows:
+
+- PR #891 was merged to `main`
+- `main` contains `docs/specs/patch-5-pseudo-orchestration.md`
+- only one specification file was added by Patch 5
+- no workflow files were changed
+- no scripts were changed
+- no tests were changed
+- no generated outputs were committed
+- safety boundary remained intact
+
+## Notes
+
+Patch 5 is the foundation for later pseudo-orchestration work.
+
+Planned follow-up roadmap:
+
+- Patch 6: reasoned agent return mediation gate
+- Patch 7: revised submission verification loop
+- Patch 8: mediation loop guard
+- Patch 9: agent rotation escalation gate
+- Patch 10: mediation checkpoint handoff
+
+These follow-up patches are not implemented by Patch 5.


### PR DESCRIPTION
## Summary
- Add Patch 5 completion / release note.
- Record that Patch 5 pseudo-orchestration specification was merged via PR #891.
- Document Patch 5 scope, safety boundary, verification, and follow-up roadmap.

## Safety boundary
- Documentation-only change.
- No workflow changes.
- No script changes.
- No test changes.
- No generated outputs committed.
- No AI API calls.
- No secrets.
- No external provider calls.
- No runtime network behavior.
- No auto-fix, auto-PR, auto-merge, or deploy behavior.

## Verification
- Branch compare against `main` shows exactly one added release note file.
- `patch-5-release-note` is ahead by 1 and behind by 0.
- Changed file: `docs/release-notes/patch-5-pseudo-orchestration.md`.