### PR TITLE
Integrate Patch 13 hash-chain checks into CI

### DIFF
--- a/.github/workflows/tasukeru-analysis.yml
+++ b/.github/workflows/tasukeru-analysis.yml
@@ -419,6 +419,15 @@ jobs:
             --out-dir stress_results/arl
           python -m unittest discover -s tests/stress -p "test_*.py"
 
+      - name: Generate Patch 13 ARL hash-chain stress artifacts
+        if: always()
+        run: |
+          set -euo pipefail
+          python -m py_compile scripts/tasukeru_arl_hash_chain_stress.py
+          python scripts/tasukeru_arl_hash_chain_stress.py \
+            --fixtures-dir tests/stress/fixtures/arl_hash_chain \
+            --output-dir stress_results/arl_hash_chain
+
       - name: Generate explainable patch proposal artifacts
         if: always()
         run: |
@@ -9616,6 +9625,14 @@ jobs:
         with:
           name: tasukeru-arl-stress-results
           path: stress_results/arl/
+          if-no-files-found: warn
+
+      - name: Upload ARL hash-chain stress artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: tasukeru-arl-hash-chain-stress-results
+          path: stress_results/arl_hash_chain/
           if-no-files-found: warn
 
       - name: Upload ARL analyzer graph artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 analysis_results/arl/
 stress_results/arl/
+stress_results/arl_hash_chain/


### PR DESCRIPTION
## Summary

Integrates the existing Patch 13 ARL hash-chain verifier into the read-only Tasukeru CI workflow.

This change:

- runs the deterministic seven-case hash-chain verification
- writes the three Patch 13 result artifacts to `stress_results/arl_hash_chain/`
- uploads them as `tasukeru-arl-hash-chain-stress-results`
- excludes generated outputs through `.gitignore`

## Changed files

- `.github/workflows/tasukeru-analysis.yml`
- `.gitignore`

## Verification

- Python compilation passed
- Focused tests: 39 passed
- Full stress discovery: 58 passed
- Canonical CLI: exit code 0
- Verify artifact: `verified: true`
- Seven fixture cases passed
- Two independent output runs were byte-identical
- `git diff --check` passed
- Generated outputs are not included in the commit

## Safety boundaries

- No workflow permission changes
- No workflow trigger changes
- No analyzer or runtime ARL changes
- No external AI API calls
- No API keys or secrets
- No automatic repair or retry
- No automatic commit, push, PR, merge, or deployment
- Human review remains required
- The historical Windows-invalid path was not modified

## Scope

This PR is limited to Patch 13 Phase 3 repository CI integration.

Analyzer integration and runtime ARL integration remain out of scope.