### PR TITLE
Add Patch 13 hash-chain analyzer

### DIFF
--- a/.github/workflows/tasukeru-analysis.yml
+++ b/.github/workflows/tasukeru-analysis.yml
@@ -428,6 +428,15 @@ jobs:
             --fixtures-dir tests/stress/fixtures/arl_hash_chain \
             --output-dir stress_results/arl_hash_chain
 
+      - name: Generate Patch 13 ARL hash-chain analyzer artifacts
+        if: always()
+        run: |
+          set -euo pipefail
+          python -m py_compile scripts/tasukeru_arl_hash_chain_analyzer.py
+          python scripts/tasukeru_arl_hash_chain_analyzer.py \
+            --input-dir stress_results/arl_hash_chain \
+            --output-dir analysis_results/arl_hash_chain
+
       - name: Generate explainable patch proposal artifacts
         if: always()
         run: |
@@ -9633,6 +9642,14 @@ jobs:
         with:
           name: tasukeru-arl-hash-chain-stress-results
           path: stress_results/arl_hash_chain/
+          if-no-files-found: warn
+
+      - name: Upload ARL hash-chain analyzer artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: tasukeru-arl-hash-chain-analyzer-results
+          path: analysis_results/arl_hash_chain/
           if-no-files-found: warn
 
       - name: Upload ARL analyzer graph artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 analysis_results/arl/
+analysis_results/arl_hash_chain/
 stress_results/arl/
 stress_results/arl_hash_chain/

--- a/scripts/tasukeru_arl_hash_chain_analyzer.py
+++ b/scripts/tasukeru_arl_hash_chain_analyzer.py
@@ -1,0 +1,1634 @@
+#!/usr/bin/env python3
+"""Deterministic, advisory-only analyzer for Patch 13 hash-chain artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Iterable, Sequence
+
+
+RESULT_SCHEMA_VERSION = "tasukeru-arl-hash-chain-analyzer-v0.1"
+GRAPH_SCHEMA_VERSION = "tasukeru-arl-hash-chain-graph-v0.1"
+VERIFY_SCHEMA_VERSION = "tasukeru-arl-hash-chain-analyzer-verify-v0.1"
+SOURCE_RESULT_SCHEMA_VERSION = "tasukeru-arl-hash-chain-stress-v0.1"
+SOURCE_VERIFY_SCHEMA_VERSION = "tasukeru-arl-hash-chain-stress-verify-v0.1"
+SOURCE_MANIFEST_SCHEMA_VERSION = "tasukeru-arl-hash-chain-fixture-manifest-v0.1"
+DETERMINISTIC_GENERATED_AT_UTC = "1970-01-01T00:00:00Z"
+
+RESULT_FILENAME = "tasukeru_arl_hash_chain_analyzer_result.json"
+GRAPH_FILENAME = "tasukeru_arl_hash_chain_graph.json"
+REPORT_FILENAME = "tasukeru_arl_hash_chain_analyzer_report.md"
+VERIFY_FILENAME = "tasukeru_arl_hash_chain_analyzer_verify.json"
+
+SOURCE_RESULT_FILENAME = "tasukeru_arl_hash_chain_stress_result.json"
+SOURCE_REPORT_FILENAME = "tasukeru_arl_hash_chain_stress_report.md"
+SOURCE_VERIFY_FILENAME = "tasukeru_arl_hash_chain_stress_verify.json"
+LOGICAL_SOURCE_ROOT = "stress_results/arl_hash_chain"
+LOGICAL_SOURCE_ID = "patch_13_arl_hash_chain_stress_results"
+ROOT_NODE_ID = f"hash_chain_artifacts:{LOGICAL_SOURCE_ID}"
+
+EXPECTED_SOURCE_FILES = frozenset(
+    {
+        SOURCE_RESULT_FILENAME,
+        SOURCE_REPORT_FILENAME,
+        SOURCE_VERIFY_FILENAME,
+    }
+)
+EXPECTED_OUTPUT_FILES = frozenset(
+    {
+        RESULT_FILENAME,
+        GRAPH_FILENAME,
+        REPORT_FILENAME,
+        VERIFY_FILENAME,
+    }
+)
+
+CANONICAL_HEAD_HASH = (
+    "4d7a836b8a1683f3dcc29c8f7d554503e8e5612aa0d13dec1ce702035d46cd4c"
+)
+CANONICAL_MANIFEST_SHA256 = (
+    "35fc86d602cb8e7943c673499b4ed51b51a12516c2fb653d59d154485de53983"
+)
+HASH_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+SOURCE_HASH_CONTRACT = {
+    "algorithm": "sha256",
+    "canonical_json": {
+        "ensure_ascii": False,
+        "sort_keys": True,
+        "separators": [",", ":"],
+    },
+    "chain_payload": "<prev_hash>:<row_hash>",
+    "genesis": "GENESIS",
+    "row_body_excluded_fields": ["chain_hash", "row_hash"],
+}
+
+SOURCE_SAFETY_BOUNDARY = MappingProxyType(
+    {
+        "advisory_only": True,
+        "human_review_required": True,
+        "modifies_repository": False,
+        "network_call": False,
+        "ai_api_call": False,
+        "external_ai_provider": False,
+        "api_key_required": False,
+        "secret_required": False,
+        "automatic_apply": False,
+        "automatic_repair": False,
+        "automatic_commit": False,
+        "automatic_push": False,
+        "automatic_pr": False,
+        "automatic_retry": False,
+        "automatic_merge": False,
+        "automatic_deploy": False,
+    }
+)
+
+SAFETY_BOUNDARY = MappingProxyType(
+    {
+        "advisory_only": True,
+        "human_review_required": True,
+        "ai_api_call": False,
+        "api_key_required": False,
+        "github_actions_secrets_required": False,
+        "external_ai_provider": False,
+        "billable_action": False,
+        "network_call": False,
+        "automatic_repair": False,
+        "automatic_retry": False,
+        "automatic_apply": False,
+        "automatic_commit": False,
+        "automatic_push": False,
+        "automatic_pr": False,
+        "automatic_merge": False,
+        "automatic_deploy": False,
+        "runtime_arl_modified": False,
+        "existing_patch_4_analyzer_modified": False,
+        "authenticity_claimed": False,
+    }
+)
+
+INTEGRITY_REASON_CODES = frozenset(
+    {
+        "ARL_SEQUENCE_MISMATCH",
+        "ARL_RUN_ID_MISMATCH",
+        "ARL_HASH_FORMAT_INVALID",
+        "ARL_GENESIS_MISMATCH",
+        "ARL_PREV_HASH_MISMATCH",
+        "ARL_ROW_HASH_MISMATCH",
+        "ARL_CHAIN_HASH_MISMATCH",
+        "ARL_HEAD_HASH_MISMATCH",
+    }
+)
+
+CANONICAL_COUNTS = MappingProxyType(
+    {
+        "total_cases": 7,
+        "passed_cases": 7,
+        "failed_cases": 0,
+        "valid_cases": 1,
+        "expected_tamper_cases": 6,
+        "tamper_cases_detected": 6,
+        "unexpected_valid_cases": 0,
+        "input_invalid_cases": 0,
+        "total_rows_read": 27,
+        "total_integrity_errors": 19,
+    }
+)
+
+
+def _issue_contract(
+    issue_ordinal: int,
+    line_number: int,
+    reason_code: str,
+    detail: str,
+    stored_value: Any,
+    recomputed_value: Any,
+) -> MappingProxyType:
+    return MappingProxyType(
+        {
+            "issue_ordinal": issue_ordinal,
+            "line_number": line_number,
+            "reason_code": reason_code,
+            "detail": detail,
+            "stored_value": stored_value,
+            "recomputed_value": recomputed_value,
+        }
+    )
+
+
+def _head_hash_contract(
+    stored_head_hash: str,
+    recomputed_head_hash: str,
+) -> MappingProxyType:
+    return MappingProxyType(
+        {
+            "stored_head_hash": stored_head_hash,
+            "recomputed_head_hash": recomputed_head_hash,
+        }
+    )
+
+
+def _case_contract(
+    case_id: str,
+    fixture_name: str,
+    expected_outcome: str,
+    primary: str,
+    additional: Sequence[str],
+    reasons: Sequence[str],
+    row_count: int,
+    integrity_issue_count: int,
+    source_issue_count: int,
+    first_error_line: int | None,
+) -> MappingProxyType:
+    return MappingProxyType(
+        {
+            "case_id": case_id,
+            "fixture_name": fixture_name,
+            "expected_outcome": expected_outcome,
+            "actual_outcome": expected_outcome,
+            "classification": (
+                "EXPECTED_CANONICAL_VALIDATION"
+                if expected_outcome == "CHAIN_VALID"
+                else "EXPECTED_TAMPER_DETECTION"
+            ),
+            "expected_primary_reason_code": primary,
+            "expected_additional_reason_codes": tuple(additional),
+            "reason_codes": tuple(reasons),
+            "expected_row_count": row_count,
+            "integrity_error_count": integrity_issue_count,
+            "source_issue_count": source_issue_count,
+            "first_error_line": first_error_line,
+        }
+    )
+
+
+CANONICAL_CASE_CONTRACTS = (
+    _case_contract(
+        "valid_chain",
+        "valid_chain.jsonl",
+        "CHAIN_VALID",
+        "ARL_CHAIN_VALID",
+        (),
+        ("ARL_CHAIN_VALID",),
+        4,
+        0,
+        1,
+        None,
+    ),
+    _case_contract(
+        "middle_row_content_tampered",
+        "middle_row_content_tampered.jsonl",
+        "TAMPER_DETECTED",
+        "ARL_ROW_HASH_MISMATCH",
+        ("ARL_CHAIN_HASH_MISMATCH", "ARL_PREV_HASH_MISMATCH"),
+        (
+            "ARL_ROW_HASH_MISMATCH",
+            "ARL_CHAIN_HASH_MISMATCH",
+            "ARL_PREV_HASH_MISMATCH",
+        ),
+        4,
+        3,
+        3,
+        2,
+    ),
+    _case_contract(
+        "middle_row_chain_hash_tampered",
+        "middle_row_chain_hash_tampered.jsonl",
+        "TAMPER_DETECTED",
+        "ARL_CHAIN_HASH_MISMATCH",
+        (),
+        ("ARL_CHAIN_HASH_MISMATCH",),
+        4,
+        1,
+        1,
+        2,
+    ),
+    _case_contract(
+        "middle_row_prev_hash_tampered",
+        "middle_row_prev_hash_tampered.jsonl",
+        "TAMPER_DETECTED",
+        "ARL_PREV_HASH_MISMATCH",
+        ("ARL_ROW_HASH_MISMATCH", "ARL_CHAIN_HASH_MISMATCH"),
+        (
+            "ARL_PREV_HASH_MISMATCH",
+            "ARL_ROW_HASH_MISMATCH",
+            "ARL_CHAIN_HASH_MISMATCH",
+        ),
+        4,
+        4,
+        4,
+        2,
+    ),
+    _case_contract(
+        "final_row_content_tampered",
+        "final_row_content_tampered.jsonl",
+        "TAMPER_DETECTED",
+        "ARL_ROW_HASH_MISMATCH",
+        ("ARL_CHAIN_HASH_MISMATCH", "ARL_HEAD_HASH_MISMATCH"),
+        (
+            "ARL_ROW_HASH_MISMATCH",
+            "ARL_CHAIN_HASH_MISMATCH",
+            "ARL_HEAD_HASH_MISMATCH",
+        ),
+        4,
+        3,
+        3,
+        4,
+    ),
+    _case_contract(
+        "rows_reordered",
+        "rows_reordered.jsonl",
+        "TAMPER_DETECTED",
+        "ARL_SEQUENCE_MISMATCH",
+        ("ARL_PREV_HASH_MISMATCH",),
+        ("ARL_SEQUENCE_MISMATCH", "ARL_PREV_HASH_MISMATCH"),
+        4,
+        5,
+        5,
+        2,
+    ),
+    _case_contract(
+        "row_deleted",
+        "row_deleted.jsonl",
+        "TAMPER_DETECTED",
+        "ARL_SEQUENCE_MISMATCH",
+        ("ARL_PREV_HASH_MISMATCH",),
+        ("ARL_SEQUENCE_MISMATCH", "ARL_PREV_HASH_MISMATCH"),
+        3,
+        3,
+        3,
+        2,
+    ),
+)
+CANONICAL_CASE_IDS = tuple(case["case_id"] for case in CANONICAL_CASE_CONTRACTS)
+
+CANONICAL_ISSUE_CONTRACTS = MappingProxyType(
+    {
+        "valid_chain": (
+            _issue_contract(
+                1,
+                0,
+                "ARL_CHAIN_VALID",
+                "The ARL hash chain is valid.",
+                None,
+                None,
+            ),
+        ),
+        "middle_row_content_tampered": (
+            _issue_contract(
+                1,
+                2,
+                "ARL_ROW_HASH_MISMATCH",
+                "Stored row_hash does not match the recomputed row hash.",
+                "a757c406baaaaeaaed21ed667246faa1599754f5d0920f0d4964e0d36df52cfd",
+                "cbc982de9d36116d463020133d9462703c5e5a7909a211913b9af48c97b4fa7c",
+            ),
+            _issue_contract(
+                2,
+                2,
+                "ARL_CHAIN_HASH_MISMATCH",
+                "Stored chain_hash does not match the recomputed chain hash.",
+                "e47c7072dc9e57d7eed535d2dba00b149d448c74a2531f4abf63726a57616e17",
+                "2afe493a93164c4c67746ed6d85cb4f1860813013df0d9af36b16c88fc2da036",
+            ),
+            _issue_contract(
+                3,
+                3,
+                "ARL_PREV_HASH_MISMATCH",
+                "prev_hash does not match the previous recomputed chain_hash.",
+                "e47c7072dc9e57d7eed535d2dba00b149d448c74a2531f4abf63726a57616e17",
+                "2afe493a93164c4c67746ed6d85cb4f1860813013df0d9af36b16c88fc2da036",
+            ),
+        ),
+        "middle_row_chain_hash_tampered": (
+            _issue_contract(
+                1,
+                2,
+                "ARL_CHAIN_HASH_MISMATCH",
+                "Stored chain_hash does not match the recomputed chain hash.",
+                "047c7072dc9e57d7eed535d2dba00b149d448c74a2531f4abf63726a57616e17",
+                "e47c7072dc9e57d7eed535d2dba00b149d448c74a2531f4abf63726a57616e17",
+            ),
+        ),
+        "middle_row_prev_hash_tampered": (
+            _issue_contract(
+                1,
+                2,
+                "ARL_PREV_HASH_MISMATCH",
+                "prev_hash does not match the previous recomputed chain_hash.",
+                "0ea9862ab6eb2d9bbc900ba7e796a70c3d80df357a1061cae2c7e7dd20c23ef3",
+                "cea9862ab6eb2d9bbc900ba7e796a70c3d80df357a1061cae2c7e7dd20c23ef3",
+            ),
+            _issue_contract(
+                2,
+                2,
+                "ARL_ROW_HASH_MISMATCH",
+                "Stored row_hash does not match the recomputed row hash.",
+                "a757c406baaaaeaaed21ed667246faa1599754f5d0920f0d4964e0d36df52cfd",
+                "3d2dfa51c59c9243c60c877d53e49417fb918d4c1096c86d959e94b6281b0eeb",
+            ),
+            _issue_contract(
+                3,
+                2,
+                "ARL_CHAIN_HASH_MISMATCH",
+                "Stored chain_hash does not match the recomputed chain hash.",
+                "e47c7072dc9e57d7eed535d2dba00b149d448c74a2531f4abf63726a57616e17",
+                "c9e49bf26b36a5459b5f2e56f57698757aa6462f5f8cf5cd7cac97fbfbd2fa6b",
+            ),
+            _issue_contract(
+                4,
+                3,
+                "ARL_PREV_HASH_MISMATCH",
+                "prev_hash does not match the previous recomputed chain_hash.",
+                "e47c7072dc9e57d7eed535d2dba00b149d448c74a2531f4abf63726a57616e17",
+                "c9e49bf26b36a5459b5f2e56f57698757aa6462f5f8cf5cd7cac97fbfbd2fa6b",
+            ),
+        ),
+        "final_row_content_tampered": (
+            _issue_contract(
+                1,
+                4,
+                "ARL_ROW_HASH_MISMATCH",
+                "Stored row_hash does not match the recomputed row hash.",
+                "42af5bd70a472767a02c26a4ac92cfc23cea9514ee092081ca123d08c2cbcb92",
+                "8cf02f9e3025871ed75ba96058e51b589ef6d4bca0c515d3aa25be3fb9d12280",
+            ),
+            _issue_contract(
+                2,
+                4,
+                "ARL_CHAIN_HASH_MISMATCH",
+                "Stored chain_hash does not match the recomputed chain hash.",
+                "4d7a836b8a1683f3dcc29c8f7d554503e8e5612aa0d13dec1ce702035d46cd4c",
+                "19ea9312e2c0c50f536f29681027579d9cfd8461bd39fee35eaa1e623229baa3",
+            ),
+            _issue_contract(
+                3,
+                4,
+                "ARL_HEAD_HASH_MISMATCH",
+                "Recomputed head hash does not match the fixture manifest.",
+                "19ea9312e2c0c50f536f29681027579d9cfd8461bd39fee35eaa1e623229baa3",
+                "4d7a836b8a1683f3dcc29c8f7d554503e8e5612aa0d13dec1ce702035d46cd4c",
+            ),
+        ),
+        "rows_reordered": (
+            _issue_contract(
+                1,
+                2,
+                "ARL_SEQUENCE_MISMATCH",
+                "seq must begin at 1 and increase by exactly 1.",
+                3,
+                2,
+            ),
+            _issue_contract(
+                2,
+                2,
+                "ARL_PREV_HASH_MISMATCH",
+                "prev_hash does not match the previous recomputed chain_hash.",
+                "e47c7072dc9e57d7eed535d2dba00b149d448c74a2531f4abf63726a57616e17",
+                "cea9862ab6eb2d9bbc900ba7e796a70c3d80df357a1061cae2c7e7dd20c23ef3",
+            ),
+            _issue_contract(
+                3,
+                3,
+                "ARL_SEQUENCE_MISMATCH",
+                "seq must begin at 1 and increase by exactly 1.",
+                2,
+                3,
+            ),
+            _issue_contract(
+                4,
+                3,
+                "ARL_PREV_HASH_MISMATCH",
+                "prev_hash does not match the previous recomputed chain_hash.",
+                "cea9862ab6eb2d9bbc900ba7e796a70c3d80df357a1061cae2c7e7dd20c23ef3",
+                "a94f54864eff401cd740c05844d0145145f5a1c47b183bbcffb5bcbebe940f3c",
+            ),
+            _issue_contract(
+                5,
+                4,
+                "ARL_PREV_HASH_MISMATCH",
+                "prev_hash does not match the previous recomputed chain_hash.",
+                "a94f54864eff401cd740c05844d0145145f5a1c47b183bbcffb5bcbebe940f3c",
+                "e47c7072dc9e57d7eed535d2dba00b149d448c74a2531f4abf63726a57616e17",
+            ),
+        ),
+        "row_deleted": (
+            _issue_contract(
+                1,
+                2,
+                "ARL_SEQUENCE_MISMATCH",
+                "seq must begin at 1 and increase by exactly 1.",
+                3,
+                2,
+            ),
+            _issue_contract(
+                2,
+                2,
+                "ARL_PREV_HASH_MISMATCH",
+                "prev_hash does not match the previous recomputed chain_hash.",
+                "e47c7072dc9e57d7eed535d2dba00b149d448c74a2531f4abf63726a57616e17",
+                "cea9862ab6eb2d9bbc900ba7e796a70c3d80df357a1061cae2c7e7dd20c23ef3",
+            ),
+            _issue_contract(
+                3,
+                3,
+                "ARL_SEQUENCE_MISMATCH",
+                "seq must begin at 1 and increase by exactly 1.",
+                4,
+                3,
+            ),
+        ),
+    }
+)
+
+CANONICAL_HEAD_HASH_CONTRACTS = MappingProxyType(
+    {
+        "valid_chain": _head_hash_contract(
+            CANONICAL_HEAD_HASH,
+            CANONICAL_HEAD_HASH,
+        ),
+        "middle_row_content_tampered": _head_hash_contract(
+            CANONICAL_HEAD_HASH,
+            CANONICAL_HEAD_HASH,
+        ),
+        "middle_row_chain_hash_tampered": _head_hash_contract(
+            CANONICAL_HEAD_HASH,
+            CANONICAL_HEAD_HASH,
+        ),
+        "middle_row_prev_hash_tampered": _head_hash_contract(
+            CANONICAL_HEAD_HASH,
+            CANONICAL_HEAD_HASH,
+        ),
+        "final_row_content_tampered": _head_hash_contract(
+            CANONICAL_HEAD_HASH,
+            "19ea9312e2c0c50f536f29681027579d9cfd8461bd39fee35eaa1e623229baa3",
+        ),
+        "rows_reordered": _head_hash_contract(
+            CANONICAL_HEAD_HASH,
+            CANONICAL_HEAD_HASH,
+        ),
+        "row_deleted": _head_hash_contract(
+            CANONICAL_HEAD_HASH,
+            CANONICAL_HEAD_HASH,
+        ),
+    }
+)
+
+SOURCE_RESULT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "generated_at_utc",
+        "mode",
+        "hash_contract",
+        "fixture_directory",
+        "manifest_path",
+        "manifest_schema_version",
+        "manifest_sha256",
+        "safety_boundary",
+        "cases",
+        "counts",
+        "checks",
+        "overall_outcome",
+        "overall_reason_codes",
+        "failure_detail",
+        "verified",
+    }
+)
+SOURCE_VERIFY_FIELDS = frozenset(
+    {
+        "schema_version",
+        "generated_at_utc",
+        "verified",
+        "checks",
+        "counts",
+        "result_sha256",
+        "report_sha256",
+        "manifest_sha256",
+        "safety_boundary",
+        "hmac_enabled",
+        "authenticity_claimed",
+    }
+)
+SOURCE_CASE_FIELDS = frozenset(
+    {
+        "case_id",
+        "fixture_name",
+        "expected_outcome",
+        "actual_outcome",
+        "expected_primary_reason_code",
+        "expected_additional_reason_codes",
+        "reason_codes",
+        "file_exists",
+        "line_count",
+        "parsed_row_count",
+        "expected_row_count",
+        "stored_head_hash",
+        "recomputed_head_hash",
+        "first_error_line",
+        "integrity_error_count",
+        "expected_condition_detected",
+        "reason_code_sequence_valid",
+        "passed",
+        "issues",
+    }
+)
+SOURCE_ISSUE_FIELDS = frozenset(
+    {
+        "line_number",
+        "reason_code",
+        "detail",
+        "stored_value",
+        "recomputed_value",
+    }
+)
+SOURCE_RESULT_CHECK_KEYS = frozenset(
+    {
+        "manifest_valid",
+        "required_cases_present",
+        "canonical_valid_chain_passed",
+        "expected_tamper_cases_detected",
+        "reason_code_contract_valid",
+        "counts_consistent",
+        "safety_boundary_verified",
+    }
+)
+SOURCE_VERIFY_CHECK_KEYS = SOURCE_RESULT_CHECK_KEYS | {
+    "output_files_exist",
+    "output_filename_set_exact",
+}
+
+
+class AnalyzerOperationalError(RuntimeError):
+    """Stable, path-free operational failure."""
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class SourceDocuments:
+    result: dict[str, Any]
+    verify: dict[str, Any]
+    report_text: str
+    raw_bytes: dict[str, bytes]
+    sha256: dict[str, str]
+
+
+def json_dump(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def canonical_hash(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def stable_token(value: Any) -> str:
+    text = str(value if value is not None else "unknown").strip().lower()
+    token = "_".join(
+        part
+        for part in "".join(char if char.isalnum() else "_" for char in text).split("_")
+        if part
+    )
+    return token[:80] or "unknown"
+
+
+def stable_id(kind: str, *parts: Any) -> str:
+    raw_parts = [str(part) for part in parts]
+    payload = json.dumps([kind, *raw_parts], ensure_ascii=False, separators=(",", ":"))
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    label = stable_token(raw_parts[0] if raw_parts else kind)
+    return f"{kind}:{label}:{digest}"
+
+
+def write_text_lf(path: Path, text: str) -> None:
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n").rstrip("\n") + "\n"
+    with path.open("w", encoding="utf-8", newline="\n") as output_file:
+        output_file.write(normalized)
+
+
+def _decode_utf8(data: bytes, reason_code: str) -> str:
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise AnalyzerOperationalError(
+            reason_code,
+            "A required source document is not valid UTF-8.",
+        ) from exc
+
+
+def _parse_json_object(text: str, reason_code: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise AnalyzerOperationalError(
+            reason_code,
+            "A required source JSON document is invalid.",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise AnalyzerOperationalError(
+            reason_code,
+            "A required source JSON document must be an object.",
+        )
+    return payload
+
+
+def validate_input_directory(input_dir: Path) -> None:
+    if not input_dir.exists() or not input_dir.is_dir():
+        raise AnalyzerOperationalError(
+            "ARL_ANALYZER_INPUT_DIRECTORY_INVALID",
+            "The input directory is missing or is not a directory.",
+        )
+    try:
+        entries = list(input_dir.iterdir())
+    except OSError as exc:
+        raise AnalyzerOperationalError(
+            "ARL_ANALYZER_INPUT_DIRECTORY_UNREADABLE",
+            "The input directory cannot be read.",
+        ) from exc
+    actual_names = {entry.name for entry in entries}
+    if actual_names != EXPECTED_SOURCE_FILES or any(not entry.is_file() for entry in entries):
+        missing = EXPECTED_SOURCE_FILES - actual_names
+        extra = actual_names - EXPECTED_SOURCE_FILES
+        reason = (
+            "ARL_ANALYZER_SOURCE_FILE_MISSING"
+            if missing
+            else "ARL_ANALYZER_UNEXPECTED_SOURCE_ENTRY"
+        )
+        raise AnalyzerOperationalError(
+            reason,
+            "The input directory must contain exactly the three required source files.",
+        )
+
+
+def validate_output_directory(input_dir: Path, output_dir: Path) -> None:
+    try:
+        input_resolved = input_dir.resolve()
+        output_resolved = output_dir.resolve()
+    except OSError as exc:
+        raise AnalyzerOperationalError(
+            "ARL_ANALYZER_PATH_RESOLUTION_FAILED",
+            "Input and output paths cannot be resolved.",
+        ) from exc
+    if output_resolved == input_resolved or input_resolved in output_resolved.parents:
+        raise AnalyzerOperationalError(
+            "ARL_ANALYZER_INPUT_OUTPUT_OVERLAP",
+            "The output directory must be separate from the input directory.",
+        )
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            raise AnalyzerOperationalError(
+                "ARL_ANALYZER_OUTPUT_DIRECTORY_INVALID",
+                "The output path exists and is not a directory.",
+            )
+        try:
+            if any(output_dir.iterdir()):
+                raise AnalyzerOperationalError(
+                    "ARL_ANALYZER_OUTPUT_DIRECTORY_NOT_EMPTY",
+                    "The output directory must be empty before generation.",
+                )
+        except OSError as exc:
+            raise AnalyzerOperationalError(
+                "ARL_ANALYZER_OUTPUT_DIRECTORY_UNREADABLE",
+                "The output directory cannot be inspected.",
+            ) from exc
+
+
+def load_source_documents(input_dir: Path) -> SourceDocuments:
+    validate_input_directory(input_dir)
+    raw_bytes: dict[str, bytes] = {}
+    for filename in sorted(EXPECTED_SOURCE_FILES):
+        try:
+            raw_bytes[filename] = (input_dir / filename).read_bytes()
+        except OSError as exc:
+            raise AnalyzerOperationalError(
+                "ARL_ANALYZER_SOURCE_READ_FAILED",
+                "A required source document cannot be read.",
+            ) from exc
+
+    result_text = _decode_utf8(
+        raw_bytes[SOURCE_RESULT_FILENAME],
+        "ARL_ANALYZER_RESULT_UTF8_INVALID",
+    )
+    report_text = _decode_utf8(
+        raw_bytes[SOURCE_REPORT_FILENAME],
+        "ARL_ANALYZER_REPORT_UTF8_INVALID",
+    )
+    verify_text = _decode_utf8(
+        raw_bytes[SOURCE_VERIFY_FILENAME],
+        "ARL_ANALYZER_VERIFY_UTF8_INVALID",
+    )
+    result = _parse_json_object(result_text, "ARL_ANALYZER_RESULT_JSON_INVALID")
+    verify = _parse_json_object(verify_text, "ARL_ANALYZER_VERIFY_JSON_INVALID")
+    if result.get("schema_version") != SOURCE_RESULT_SCHEMA_VERSION:
+        raise AnalyzerOperationalError(
+            "ARL_ANALYZER_RESULT_SCHEMA_UNSUPPORTED",
+            "The source result schema version is unsupported.",
+        )
+    if verify.get("schema_version") != SOURCE_VERIFY_SCHEMA_VERSION:
+        raise AnalyzerOperationalError(
+            "ARL_ANALYZER_VERIFY_SCHEMA_UNSUPPORTED",
+            "The source verify schema version is unsupported.",
+        )
+    return SourceDocuments(
+        result=result,
+        verify=verify,
+        report_text=report_text,
+        raw_bytes=raw_bytes,
+        sha256={
+            filename: sha256_bytes(data)
+            for filename, data in sorted(raw_bytes.items())
+        },
+    )
+
+
+def _is_boolean_map(value: Any, expected_keys: frozenset[str]) -> bool:
+    return (
+        isinstance(value, dict)
+        and set(value) == expected_keys
+        and all(isinstance(item, bool) for item in value.values())
+        and all(value.values())
+    )
+
+
+def _is_lower_sha256(value: Any) -> bool:
+    return isinstance(value, str) and HASH_PATTERN.fullmatch(value) is not None
+
+
+def _list_value(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _dict_value(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _reason_role(
+    reason_code: str,
+    order: int,
+    primary: str,
+    allowed_additional: Sequence[str],
+) -> str:
+    if order == 1 and reason_code == primary:
+        return "primary"
+    if order > 1 and reason_code in allowed_additional:
+        return "additional"
+    return "unexpected"
+
+
+def normalize_case(source_case: Any) -> dict[str, Any]:
+    case = _dict_value(source_case)
+    primary = str(case.get("expected_primary_reason_code", ""))
+    additional = [
+        str(value) for value in _list_value(case.get("expected_additional_reason_codes"))
+    ]
+    reasons = []
+    for order, value in enumerate(_list_value(case.get("reason_codes")), start=1):
+        reason_code = str(value)
+        reasons.append(
+            {
+                "reason_code": reason_code,
+                "order": order,
+                "role": _reason_role(reason_code, order, primary, additional),
+            }
+        )
+
+    issues = []
+    for ordinal, value in enumerate(_list_value(case.get("issues")), start=1):
+        issue = _dict_value(value)
+        reason_code = str(issue.get("reason_code", ""))
+        issues.append(
+            {
+                "issue_ordinal": ordinal,
+                "line_number": issue.get("line_number"),
+                "reason_code": reason_code,
+                "detail": issue.get("detail"),
+                "stored_value": issue.get("stored_value"),
+                "recomputed_value": issue.get("recomputed_value"),
+                "is_integrity_issue": reason_code in INTEGRITY_REASON_CODES,
+            }
+        )
+
+    case_id = str(case.get("case_id", ""))
+    classification = next(
+        (
+            contract["classification"]
+            for contract in CANONICAL_CASE_CONTRACTS
+            if contract["case_id"] == case_id
+        ),
+        "UNRECOGNIZED_CASE",
+    )
+    return {
+        "case_id": case_id,
+        "fixture_name": case.get("fixture_name"),
+        "classification": classification,
+        "expected_outcome": case.get("expected_outcome"),
+        "actual_outcome": case.get("actual_outcome"),
+        "expected_primary_reason_code": primary,
+        "expected_additional_reason_codes": additional,
+        "reasons": reasons,
+        "reason_code_sequence_valid": case.get("reason_code_sequence_valid") is True,
+        "file_exists": case.get("file_exists") is True,
+        "line_count": case.get("line_count"),
+        "parsed_row_count": case.get("parsed_row_count"),
+        "expected_row_count": case.get("expected_row_count"),
+        "expected_canonical_head_hash": CANONICAL_HEAD_HASH,
+        "stored_head_hash": case.get("stored_head_hash"),
+        "recomputed_head_hash": case.get("recomputed_head_hash"),
+        "first_error_line": case.get("first_error_line"),
+        "integrity_error_count": case.get("integrity_error_count"),
+        "expected_condition_detected": case.get("expected_condition_detected") is True,
+        "passed": case.get("passed") is True,
+        "issues": issues,
+    }
+
+
+def compute_counts_from_cases(cases: Sequence[Any]) -> dict[str, int]:
+    case_dicts = [_dict_value(case) for case in cases]
+    return {
+        "total_cases": len(case_dicts),
+        "passed_cases": sum(case.get("passed") is True for case in case_dicts),
+        "failed_cases": sum(case.get("passed") is not True for case in case_dicts),
+        "valid_cases": sum(
+            case.get("actual_outcome") == "CHAIN_VALID" for case in case_dicts
+        ),
+        "expected_tamper_cases": sum(
+            case.get("expected_outcome") == "TAMPER_DETECTED"
+            for case in case_dicts
+        ),
+        "tamper_cases_detected": sum(
+            case.get("expected_outcome") == "TAMPER_DETECTED"
+            and case.get("actual_outcome") == "TAMPER_DETECTED"
+            for case in case_dicts
+        ),
+        "unexpected_valid_cases": sum(
+            "ARL_EXPECTED_DETECTION_MISSING"
+            in _list_value(case.get("reason_codes"))
+            for case in case_dicts
+        ),
+        "input_invalid_cases": sum(
+            case.get("actual_outcome") == "INPUT_INVALID" for case in case_dicts
+        ),
+        "total_rows_read": sum(
+            value
+            for case in case_dicts
+            if isinstance((value := case.get("parsed_row_count")), int)
+            and not isinstance(value, bool)
+        ),
+        "total_integrity_errors": sum(
+            value
+            for case in case_dicts
+            if isinstance((value := case.get("integrity_error_count")), int)
+            and not isinstance(value, bool)
+        ),
+    }
+
+
+def validate_case_contract(cases: Sequence[Any]) -> dict[str, bool]:
+    case_dicts = [_dict_value(case) for case in cases]
+    exact_count_and_order = (
+        len(case_dicts) == len(CANONICAL_CASE_CONTRACTS)
+        and tuple(case.get("case_id") for case in case_dicts) == CANONICAL_CASE_IDS
+    )
+    exact_fields = all(set(case) == SOURCE_CASE_FIELDS for case in case_dicts)
+    semantics_valid = exact_count_and_order and exact_fields
+    reasons_valid = exact_count_and_order and exact_fields
+    issues_valid = exact_count_and_order and exact_fields
+    head_hashes_valid = exact_count_and_order and exact_fields
+
+    if exact_count_and_order and exact_fields:
+        for case, contract in zip(
+            case_dicts,
+            CANONICAL_CASE_CONTRACTS,
+            strict=True,
+        ):
+            semantics_valid = semantics_valid and all(
+                (
+                    case.get("fixture_name") == contract["fixture_name"],
+                    case.get("expected_outcome") == contract["expected_outcome"],
+                    case.get("actual_outcome") == contract["actual_outcome"],
+                    case.get("expected_primary_reason_code")
+                    == contract["expected_primary_reason_code"],
+                    tuple(_list_value(case.get("expected_additional_reason_codes")))
+                    == contract["expected_additional_reason_codes"],
+                    case.get("file_exists") is True,
+                    case.get("line_count") == contract["expected_row_count"],
+                    case.get("parsed_row_count") == contract["expected_row_count"],
+                    case.get("expected_row_count") == contract["expected_row_count"],
+                    case.get("first_error_line") == contract["first_error_line"],
+                    case.get("integrity_error_count")
+                    == contract["integrity_error_count"],
+                    case.get("expected_condition_detected") is True,
+                    case.get("reason_code_sequence_valid") is True,
+                    case.get("passed") is True,
+                )
+            )
+            reason_codes = _list_value(case.get("reason_codes"))
+            reasons_valid = reasons_valid and (
+                tuple(reason_codes) == contract["reason_codes"]
+                and len(reason_codes) == len(set(reason_codes))
+                and reason_codes[0] == contract["expected_primary_reason_code"]
+            )
+            source_issues = _list_value(case.get("issues"))
+            issue_fields_valid = all(
+                isinstance(issue, dict) and set(issue) == SOURCE_ISSUE_FIELDS
+                for issue in source_issues
+            )
+            integrity_count = sum(
+                isinstance(issue, dict)
+                and issue.get("reason_code") in INTEGRITY_REASON_CODES
+                for issue in source_issues
+            )
+            expected_issues = CANONICAL_ISSUE_CONTRACTS[case["case_id"]]
+            exact_issue_evidence = (
+                len(source_issues) == len(expected_issues)
+                and all(
+                    isinstance(issue, dict)
+                    and {
+                        "issue_ordinal": ordinal,
+                        "line_number": issue.get("line_number"),
+                        "reason_code": issue.get("reason_code"),
+                        "detail": issue.get("detail"),
+                        "stored_value": issue.get("stored_value"),
+                        "recomputed_value": issue.get("recomputed_value"),
+                    }
+                    == dict(expected_issue)
+                    for ordinal, (issue, expected_issue) in enumerate(
+                        zip(source_issues, expected_issues, strict=True),
+                        start=1,
+                    )
+                )
+            )
+            issues_valid = issues_valid and (
+                len(source_issues) == contract["source_issue_count"]
+                and issue_fields_valid
+                and integrity_count == contract["integrity_error_count"]
+                and exact_issue_evidence
+            )
+            head_hash_contract = CANONICAL_HEAD_HASH_CONTRACTS[case["case_id"]]
+            head_hashes_valid = head_hashes_valid and (
+                case.get("stored_head_hash")
+                == head_hash_contract["stored_head_hash"]
+                and case.get("recomputed_head_hash")
+                == head_hash_contract["recomputed_head_hash"]
+            )
+
+    return {
+        "canonical_case_order_valid": exact_count_and_order,
+        "canonical_case_fields_valid": exact_fields,
+        "canonical_case_semantics_valid": semantics_valid,
+        "reason_code_order_valid": reasons_valid,
+        "source_issue_contract_valid": issues_valid,
+        "head_hash_evidence_valid": head_hashes_valid,
+    }
+
+
+def build_source_checks(source: SourceDocuments) -> dict[str, bool]:
+    result = source.result
+    verify = source.verify
+    cases = _list_value(result.get("cases"))
+    case_checks = validate_case_contract(cases)
+    computed_counts = compute_counts_from_cases(cases)
+    source_counts = result.get("counts")
+    verify_counts = verify.get("counts")
+    result_manifest = result.get("manifest_sha256")
+    verify_manifest = verify.get("manifest_sha256")
+
+    checks = {
+        "source_result_fields_exact": set(result) == SOURCE_RESULT_FIELDS,
+        "source_verify_fields_exact": set(verify) == SOURCE_VERIFY_FIELDS,
+        "source_result_verified": result.get("verified") is True,
+        "source_verify_verified": verify.get("verified") is True,
+        "source_hmac_disabled": verify.get("hmac_enabled") is False,
+        "source_authenticity_not_claimed": verify.get("authenticity_claimed")
+        is False,
+        "source_result_safety_boundary_valid": result.get("safety_boundary")
+        == dict(SOURCE_SAFETY_BOUNDARY),
+        "source_verify_safety_boundary_valid": verify.get("safety_boundary")
+        == dict(SOURCE_SAFETY_BOUNDARY),
+        "source_result_hash_matches": verify.get("result_sha256")
+        == source.sha256[SOURCE_RESULT_FILENAME],
+        "source_report_hash_matches": verify.get("report_sha256")
+        == source.sha256[SOURCE_REPORT_FILENAME],
+        "source_manifest_hash_bound": (
+            _is_lower_sha256(result_manifest)
+            and result_manifest == verify_manifest
+            and result_manifest == CANONICAL_MANIFEST_SHA256
+        ),
+        "source_result_checks_valid": _is_boolean_map(
+            result.get("checks"),
+            SOURCE_RESULT_CHECK_KEYS,
+        ),
+        "source_verify_checks_valid": _is_boolean_map(
+            verify.get("checks"),
+            SOURCE_VERIFY_CHECK_KEYS,
+        ),
+        "source_counts_match_cases": source_counts == computed_counts,
+        "source_counts_match_verify": source_counts == verify_counts,
+        "canonical_counts_valid": source_counts == dict(CANONICAL_COUNTS),
+        "source_result_metadata_valid": (
+            result.get("generated_at_utc") == DETERMINISTIC_GENERATED_AT_UTC
+            and result.get("mode") == "fixture_based_advisory_only"
+            and result.get("hash_contract") == SOURCE_HASH_CONTRACT
+            and result.get("fixture_directory") == "arl_hash_chain"
+            and result.get("manifest_path") == "arl_hash_chain/fixture_manifest.json"
+            and result.get("manifest_schema_version")
+            == SOURCE_MANIFEST_SCHEMA_VERSION
+            and result.get("overall_outcome") == "CHAIN_VALID"
+            and result.get("overall_reason_codes") == ["ARL_CHAIN_VALID"]
+            and result.get("failure_detail") is None
+        ),
+        "source_verify_metadata_valid": verify.get("generated_at_utc")
+        == DETERMINISTIC_GENERATED_AT_UTC,
+        "analyzer_safety_boundary_valid": dict(SAFETY_BOUNDARY)
+        == {
+            "advisory_only": True,
+            "human_review_required": True,
+            "ai_api_call": False,
+            "api_key_required": False,
+            "github_actions_secrets_required": False,
+            "external_ai_provider": False,
+            "billable_action": False,
+            "network_call": False,
+            "automatic_repair": False,
+            "automatic_retry": False,
+            "automatic_apply": False,
+            "automatic_commit": False,
+            "automatic_push": False,
+            "automatic_pr": False,
+            "automatic_merge": False,
+            "automatic_deploy": False,
+            "runtime_arl_modified": False,
+            "existing_patch_4_analyzer_modified": False,
+            "authenticity_claimed": False,
+        },
+    }
+    checks.update(case_checks)
+    normalized = [normalize_case(case) for case in cases]
+    checks["all_source_issues_preserved"] = sum(
+        len(case["issues"]) for case in normalized
+    ) == sum(
+        len(_list_value(_dict_value(case).get("issues"))) for case in cases
+    )
+    checks["nineteen_integrity_issues_preserved"] = sum(
+        issue["is_integrity_issue"]
+        for case in normalized
+        for issue in case["issues"]
+    ) == CANONICAL_COUNTS["total_integrity_errors"]
+    return dict(sorted(checks.items()))
+
+
+def add_node(
+    nodes: dict[str, dict[str, Any]],
+    node_id: str,
+    node_type: str,
+    label: str,
+    **properties: Any,
+) -> None:
+    nodes[node_id] = {
+        "id": node_id,
+        "type": node_type,
+        "label": label,
+        "properties": dict(sorted(properties.items())),
+    }
+
+
+def add_edge(
+    edges: dict[str, dict[str, Any]],
+    source: str,
+    target: str,
+    edge_type: str,
+    **properties: Any,
+) -> None:
+    ordered_properties = dict(sorted(properties.items()))
+    edge_id = stable_id(
+        "edge",
+        source,
+        edge_type,
+        target,
+        canonical_hash(ordered_properties),
+    )
+    edges[edge_id] = {
+        "id": edge_id,
+        "source": source,
+        "target": target,
+        "type": edge_type,
+        "properties": ordered_properties,
+    }
+
+
+def build_graph(
+    cases: Sequence[dict[str, Any]],
+    source: SourceDocuments,
+    checks: dict[str, bool],
+) -> dict[str, Any]:
+    nodes: dict[str, dict[str, Any]] = {}
+    edges: dict[str, dict[str, Any]] = {}
+    add_node(
+        nodes,
+        ROOT_NODE_ID,
+        "HashChainArtifactSet",
+        "Patch 13 ARL hash-chain stress results",
+        logical_id=LOGICAL_SOURCE_ID,
+        source_path=LOGICAL_SOURCE_ROOT,
+        verified=all(checks.values()),
+    )
+
+    for filename in sorted(EXPECTED_SOURCE_FILES):
+        source_node = stable_id("source_document", filename)
+        add_node(
+            nodes,
+            source_node,
+            "SourceDocument",
+            filename,
+            logical_path=f"{LOGICAL_SOURCE_ROOT}/{filename}",
+            sha256=source.sha256[filename],
+        )
+        add_edge(edges, ROOT_NODE_ID, source_node, "HAS_SOURCE")
+
+    verify_node = stable_id("verify_report", SOURCE_VERIFY_FILENAME)
+    add_node(
+        nodes,
+        verify_node,
+        "VerifyReport",
+        SOURCE_VERIFY_FILENAME,
+        verified=source.verify.get("verified") is True,
+        hmac_enabled=source.verify.get("hmac_enabled"),
+        authenticity_claimed=source.verify.get("authenticity_claimed"),
+    )
+    add_edge(edges, verify_node, ROOT_NODE_ID, "VERIFIES")
+
+    for case in cases:
+        case_id = case["case_id"]
+        case_node = stable_id("hash_chain_case", case_id)
+        add_node(
+            nodes,
+            case_node,
+            "HashChainCase",
+            case_id,
+            classification=case["classification"],
+            fixture_name=case["fixture_name"],
+            passed=case["passed"],
+            expected_canonical_head_hash=case["expected_canonical_head_hash"],
+            stored_head_hash=case["stored_head_hash"],
+            recomputed_head_hash=case["recomputed_head_hash"],
+            integrity_error_count=case["integrity_error_count"],
+        )
+        add_edge(edges, ROOT_NODE_ID, case_node, "HAS_CASE")
+
+        expected_value = str(case["expected_outcome"])
+        expected_node = stable_id("expected_outcome", expected_value)
+        add_node(
+            nodes,
+            expected_node,
+            "ExpectedOutcome",
+            expected_value,
+        )
+        add_edge(edges, case_node, expected_node, "EXPECTED_OUTCOME")
+
+        observed_value = str(case["actual_outcome"])
+        observed_node = stable_id("observed_outcome", observed_value)
+        add_node(
+            nodes,
+            observed_node,
+            "ObservedOutcome",
+            observed_value,
+        )
+        add_edge(edges, case_node, observed_node, "OBSERVED_OUTCOME")
+
+        for reason in case["reasons"]:
+            reason_code = reason["reason_code"]
+            reason_node = stable_id("reason_code", reason_code)
+            add_node(nodes, reason_node, "ReasonCode", reason_code)
+            add_edge(
+                edges,
+                case_node,
+                reason_node,
+                "HAS_REASON",
+                order=reason["order"],
+                role=reason["role"],
+            )
+
+        for issue in case["issues"]:
+            if not issue["is_integrity_issue"]:
+                continue
+            issue_node = stable_id(
+                "integrity_issue",
+                case_id,
+                issue["issue_ordinal"],
+                issue["line_number"],
+                issue["reason_code"],
+            )
+            add_node(
+                nodes,
+                issue_node,
+                "IntegrityIssue",
+                f"{case_id} issue {issue['issue_ordinal']}",
+                issue_ordinal=issue["issue_ordinal"],
+                line_number=issue["line_number"],
+                reason_code=issue["reason_code"],
+                detail=issue["detail"],
+                stored_value=issue["stored_value"],
+                recomputed_value=issue["recomputed_value"],
+            )
+            add_edge(
+                edges,
+                case_node,
+                issue_node,
+                "HAS_ISSUE",
+                issue_ordinal=issue["issue_ordinal"],
+            )
+
+    node_values = sorted(nodes.values(), key=lambda node: node["id"])
+    edge_values = sorted(edges.values(), key=lambda edge: edge["id"])
+    graph = {
+        "schema_version": GRAPH_SCHEMA_VERSION,
+        "generated_at_utc": DETERMINISTIC_GENERATED_AT_UTC,
+        "mode": "advisory_only_deterministic_hash_chain_graph",
+        "logical_root": LOGICAL_SOURCE_ID,
+        "nodes": node_values,
+        "edges": edge_values,
+        "counts": {
+            "nodes": len(node_values),
+            "edges": len(edge_values),
+            "cases": sum(node["type"] == "HashChainCase" for node in node_values),
+            "integrity_issues": sum(
+                node["type"] == "IntegrityIssue" for node in node_values
+            ),
+        },
+        "safety_boundary": dict(SAFETY_BOUNDARY),
+    }
+    graph["graph_hash"] = canonical_hash(
+        {
+            "schema_version": graph["schema_version"],
+            "logical_root": graph["logical_root"],
+            "nodes": graph["nodes"],
+            "edges": graph["edges"],
+        }
+    )
+    return graph
+
+
+def build_analysis(source: SourceDocuments) -> dict[str, Any]:
+    checks = build_source_checks(source)
+    normalized_cases = [
+        normalize_case(case) for case in _list_value(source.result.get("cases"))
+    ]
+    graph = build_graph(normalized_cases, source, checks)
+    checks["graph_case_count_valid"] = graph["counts"]["cases"] == 7
+    checks["graph_integrity_issue_count_valid"] = (
+        graph["counts"]["integrity_issues"] == 19
+    )
+    checks = dict(sorted(checks.items()))
+
+    result = {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "generated_at_utc": DETERMINISTIC_GENERATED_AT_UTC,
+        "mode": "advisory_only_deterministic_hash_chain_analyzer",
+        "source_contract": {
+            "logical_root": LOGICAL_SOURCE_ID,
+            "logical_path": LOGICAL_SOURCE_ROOT,
+            "required_files": sorted(EXPECTED_SOURCE_FILES),
+            "result_schema_version": SOURCE_RESULT_SCHEMA_VERSION,
+            "verify_schema_version": SOURCE_VERIFY_SCHEMA_VERSION,
+            "manifest_schema_version": SOURCE_MANIFEST_SCHEMA_VERSION,
+        },
+        "source_documents": {
+            filename: {
+                "logical_path": f"{LOGICAL_SOURCE_ROOT}/{filename}",
+                "sha256": source.sha256[filename],
+            }
+            for filename in sorted(EXPECTED_SOURCE_FILES)
+        },
+        "source_manifest_sha256": source.result.get("manifest_sha256"),
+        "safety_boundary": dict(SAFETY_BOUNDARY),
+        "cases": normalized_cases,
+        "counts": source.result.get("counts", {}),
+        "checks": checks,
+        "graph_summary": {
+            "schema_version": graph["schema_version"],
+            "node_count": graph["counts"]["nodes"],
+            "edge_count": graph["counts"]["edges"],
+            "case_count": graph["counts"]["cases"],
+            "integrity_issue_count": graph["counts"]["integrity_issues"],
+            "graph_hash": graph["graph_hash"],
+        },
+        "verified": all(checks.values()),
+    }
+    return {"result": result, "graph": graph}
+
+
+def build_report(result: dict[str, Any], graph: dict[str, Any]) -> str:
+    source_docs = result["source_documents"]
+    lines = [
+        "# Tasukeru ARL Hash-Chain Analyzer Report",
+        "",
+        "## Summary",
+        "",
+        f"- Verified: `{'true' if result['verified'] else 'false'}`",
+        f"- Cases: `{result['counts'].get('total_cases')}`",
+        f"- Expected tamper detections: `{result['counts'].get('tamper_cases_detected')}`",
+        f"- Integrity issues: `{result['counts'].get('total_integrity_errors')}`",
+        "",
+        "## Source Binding Verification",
+        "",
+    ]
+    for filename in sorted(source_docs):
+        lines.append(f"- `{filename}` SHA-256: `{source_docs[filename]['sha256']}`")
+    lines.extend(["", "## Case Classifications", ""])
+    for case in result["cases"]:
+        lines.append(
+            f"- `{case['case_id']}`: `{case['classification']}`; "
+            f"expected=`{case['expected_outcome']}`; "
+            f"observed=`{case['actual_outcome']}`; "
+            f"passed=`{'true' if case['passed'] else 'false'}`"
+        )
+    lines.extend(["", "## Reason-Code Ordering", ""])
+    for case in result["cases"]:
+        rendered = ", ".join(
+            f"{reason['order']}:{reason['reason_code']}({reason['role']})"
+            for reason in case["reasons"]
+        )
+        lines.append(f"- `{case['case_id']}`: {rendered}")
+    lines.extend(["", "## Integrity Issue Counts", ""])
+    for case in result["cases"]:
+        lines.append(
+            f"- `{case['case_id']}`: `{case['integrity_error_count']}`"
+        )
+    lines.extend(["", "## Head-Hash Evidence", ""])
+    for case in result["cases"]:
+        lines.extend(
+            [
+                f"### {case['case_id']}",
+                "",
+                f"- Expected canonical head hash: `{case['expected_canonical_head_hash']}`",
+                f"- Stored head hash: `{case['stored_head_hash']}`",
+                f"- Recomputed head hash: `{case['recomputed_head_hash']}`",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "## Graph Summary",
+            "",
+            f"- Nodes: `{graph['counts']['nodes']}`",
+            f"- Edges: `{graph['counts']['edges']}`",
+            f"- Integrity issue nodes: `{graph['counts']['integrity_issues']}`",
+            f"- Graph hash: `{graph['graph_hash']}`",
+            "",
+            "## Checks",
+            "",
+        ]
+    )
+    for name, passed in sorted(result["checks"].items()):
+        lines.append(f"- {name}: `{'true' if passed else 'false'}`")
+    lines.extend(["", "## Safety Boundary", ""])
+    for name, value in sorted(result["safety_boundary"].items()):
+        rendered = str(value).lower() if isinstance(value, bool) else str(value)
+        lines.append(f"- {name}: `{rendered}`")
+    lines.extend(
+        [
+            "",
+            "## Limitations",
+            "",
+            "- HMAC is not enabled.",
+            "- Authenticity is not claimed.",
+            "- Hash consistency is not an external identity proof.",
+            "- This artifact is advisory-only.",
+            "- Final review remains human-controlled.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_output_verify(
+    result: dict[str, Any],
+    graph: dict[str, Any],
+    *,
+    source: SourceDocuments,
+    result_path: Path,
+    graph_path: Path,
+    report_path: Path,
+    verify_path: Path,
+) -> dict[str, Any]:
+    output_existence_checks = {
+        "result_json": result_path.is_file(),
+        "graph_json": graph_path.is_file(),
+        "report_markdown": report_path.is_file(),
+        "verify_json": verify_path.is_file(),
+    }
+    try:
+        actual_names = {
+            path.name for path in verify_path.parent.iterdir() if path.is_file()
+        }
+    except OSError:
+        actual_names = set()
+    output_filename_set_exact = actual_names == EXPECTED_OUTPUT_FILES
+    checks = dict(result["checks"])
+    checks.update(
+        {
+            "graph_hash_matches": result["graph_summary"]["graph_hash"]
+            == graph["graph_hash"],
+            "output_files_exist": all(output_existence_checks.values()),
+            "output_filename_set_exact": output_filename_set_exact,
+        }
+    )
+    return {
+        "schema_version": VERIFY_SCHEMA_VERSION,
+        "generated_at_utc": DETERMINISTIC_GENERATED_AT_UTC,
+        "verified": result["verified"] and all(checks.values()),
+        "checks": dict(sorted(checks.items())),
+        "source_document_sha256": dict(sorted(source.sha256.items())),
+        "source_schema_versions": {
+            "result": source.result.get("schema_version"),
+            "verify": source.verify.get("schema_version"),
+        },
+        "source_manifest_sha256": source.result.get("manifest_sha256"),
+        "output_existence_checks": output_existence_checks,
+        "output_filename_set_exact": output_filename_set_exact,
+        "result_sha256": file_sha256(result_path) if result_path.is_file() else "",
+        "graph_sha256": file_sha256(graph_path) if graph_path.is_file() else "",
+        "report_sha256": file_sha256(report_path) if report_path.is_file() else "",
+        "graph_hash": graph["graph_hash"],
+        "counts": result["counts"],
+        "safety_boundary": dict(SAFETY_BOUNDARY),
+        "hmac_enabled": False,
+        "authenticity_claimed": False,
+    }
+
+
+def write_artifacts(
+    analysis: dict[str, Any],
+    source: SourceDocuments,
+    output_dir: Path,
+) -> dict[str, Any]:
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        result_path = output_dir / RESULT_FILENAME
+        graph_path = output_dir / GRAPH_FILENAME
+        report_path = output_dir / REPORT_FILENAME
+        verify_path = output_dir / VERIFY_FILENAME
+        result = analysis["result"]
+        graph = analysis["graph"]
+        write_text_lf(result_path, json_dump(result))
+        write_text_lf(graph_path, json_dump(graph))
+        write_text_lf(report_path, build_report(result, graph))
+
+        preliminary = build_output_verify(
+            result,
+            graph,
+            source=source,
+            result_path=result_path,
+            graph_path=graph_path,
+            report_path=report_path,
+            verify_path=verify_path,
+        )
+        write_text_lf(verify_path, json_dump(preliminary))
+        verify = build_output_verify(
+            result,
+            graph,
+            source=source,
+            result_path=result_path,
+            graph_path=graph_path,
+            report_path=report_path,
+            verify_path=verify_path,
+        )
+        write_text_lf(verify_path, json_dump(verify))
+    except AnalyzerOperationalError:
+        raise
+    except OSError as exc:
+        raise AnalyzerOperationalError(
+            "ARL_ANALYZER_OUTPUT_WRITE_FAILED",
+            "Analyzer output files could not be written.",
+        ) from exc
+    return {
+        "result_path": result_path,
+        "graph_path": graph_path,
+        "report_path": report_path,
+        "verify_path": verify_path,
+        "verify": verify,
+    }
+
+
+def run_analyzer(input_dir: Path, output_dir: Path) -> dict[str, Any]:
+    source = load_source_documents(input_dir)
+    validate_output_directory(input_dir, output_dir)
+    analysis = build_analysis(source)
+    artifacts = write_artifacts(analysis, source, output_dir)
+    return {
+        "source": source,
+        "analysis": analysis,
+        "artifacts": artifacts,
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Analyze deterministic Patch 13 ARL hash-chain artifacts."
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        required=True,
+        help="Directory containing exactly the three Patch 13 source artifacts.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Absent or empty directory for four analyzer review artifacts.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        run = run_analyzer(args.input_dir, args.output_dir)
+    except AnalyzerOperationalError as exc:
+        print(f"{exc.reason_code}: {exc.message}", file=sys.stderr)
+        return 2
+    except Exception:
+        print(
+            "ARL_ANALYZER_UNEXPECTED_ERROR: An unexpected operational error occurred.",
+            file=sys.stderr,
+        )
+        return 2
+
+    artifacts = run["artifacts"]
+    verify = artifacts["verify"]
+    print("Tasukeru ARL Hash-Chain Analyzer v0.1")
+    print(f"verified: {verify['verified']}")
+    print(f"result: {RESULT_FILENAME}")
+    print(f"graph: {GRAPH_FILENAME}")
+    print(f"report: {REPORT_FILENAME}")
+    print(f"verify: {VERIFY_FILENAME}")
+    return 0 if verify["verified"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/stress/test_tasukeru_arl_hash_chain_analyzer.py
+++ b/tests/stress/test_tasukeru_arl_hash_chain_analyzer.py
@@ -1,0 +1,1163 @@
+"""Tests for the deterministic Patch 13 hash-chain analyzer."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Callable
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+FIXTURES_DIR = PROJECT_ROOT / "tests" / "stress" / "fixtures" / "arl_hash_chain"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import tasukeru_arl_hash_chain_analyzer as analyzer  # noqa: E402
+import tasukeru_arl_hash_chain_stress as stress  # noqa: E402
+
+
+RESULT_FIELDS = {
+    "schema_version",
+    "generated_at_utc",
+    "mode",
+    "source_contract",
+    "source_documents",
+    "source_manifest_sha256",
+    "safety_boundary",
+    "cases",
+    "counts",
+    "checks",
+    "graph_summary",
+    "verified",
+}
+GRAPH_FIELDS = {
+    "schema_version",
+    "generated_at_utc",
+    "mode",
+    "logical_root",
+    "nodes",
+    "edges",
+    "counts",
+    "safety_boundary",
+    "graph_hash",
+}
+VERIFY_FIELDS = {
+    "schema_version",
+    "generated_at_utc",
+    "verified",
+    "checks",
+    "source_document_sha256",
+    "source_schema_versions",
+    "source_manifest_sha256",
+    "output_existence_checks",
+    "output_filename_set_exact",
+    "result_sha256",
+    "graph_sha256",
+    "report_sha256",
+    "graph_hash",
+    "counts",
+    "safety_boundary",
+    "hmac_enabled",
+    "authenticity_claimed",
+}
+ISSUE_FIELDS = {
+    "issue_ordinal",
+    "line_number",
+    "reason_code",
+    "detail",
+    "stored_value",
+    "recomputed_value",
+    "is_integrity_issue",
+}
+REPORT_SECTIONS = (
+    "## Summary",
+    "## Source Binding Verification",
+    "## Case Classifications",
+    "## Reason-Code Ordering",
+    "## Integrity Issue Counts",
+    "## Head-Hash Evidence",
+    "## Graph Summary",
+    "## Checks",
+    "## Safety Boundary",
+    "## Limitations",
+)
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def write_json(path: Path, payload: Any) -> None:
+    text = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    with path.open("w", encoding="utf-8", newline="\n") as output_file:
+        output_file.write(text)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError(f"Expected object in {path.name}.")
+    return payload
+
+
+class TasukeruArlHashChainAnalyzerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.source_dir = self.root / "source"
+        self.output_dir = self.root / "output"
+        result = stress.run_stress(FIXTURES_DIR)
+        self.assertTrue(result["verified"])
+        artifacts = stress.write_artifacts(result, self.source_dir)
+        self.assertTrue(artifacts["verify"]["verified"])
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def run_cli(
+        self,
+        *,
+        input_dir: Path | None = None,
+        output_dir: Path | None = None,
+    ) -> tuple[int, str, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            exit_code = analyzer.main(
+                [
+                    "--input-dir",
+                    str(input_dir or self.source_dir),
+                    "--output-dir",
+                    str(output_dir or self.output_dir),
+                ]
+            )
+        return exit_code, stdout.getvalue(), stderr.getvalue()
+
+    def run_canonical(self) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+        exit_code, _, stderr = self.run_cli()
+        self.assertEqual(exit_code, 0, stderr)
+        return (
+            load_json(self.output_dir / analyzer.RESULT_FILENAME),
+            load_json(self.output_dir / analyzer.GRAPH_FILENAME),
+            load_json(self.output_dir / analyzer.VERIFY_FILENAME),
+        )
+
+    def mutate_result(
+        self,
+        mutation: Callable[[dict[str, Any]], None],
+        *,
+        rebind: bool = True,
+    ) -> None:
+        result_path = self.source_dir / analyzer.SOURCE_RESULT_FILENAME
+        result = load_json(result_path)
+        mutation(result)
+        write_json(result_path, result)
+        if rebind:
+            verify_path = self.source_dir / analyzer.SOURCE_VERIFY_FILENAME
+            verify = load_json(verify_path)
+            verify["result_sha256"] = sha256_file(result_path)
+            write_json(verify_path, verify)
+
+    def mutate_verify(self, mutation: Callable[[dict[str, Any]], None]) -> None:
+        verify_path = self.source_dir / analyzer.SOURCE_VERIFY_FILENAME
+        verify = load_json(verify_path)
+        mutation(verify)
+        write_json(verify_path, verify)
+
+    def assert_semantic_failure(self) -> dict[str, Any]:
+        exit_code, _, stderr = self.run_cli()
+        self.assertEqual(exit_code, 1, stderr)
+        verify = load_json(self.output_dir / analyzer.VERIFY_FILENAME)
+        self.assertFalse(verify["verified"])
+        self.assertEqual(
+            {path.name for path in self.output_dir.iterdir()},
+            analyzer.EXPECTED_OUTPUT_FILES,
+        )
+        return verify
+
+    def assert_operational_failure(
+        self,
+        expected_reason: str,
+        *,
+        input_dir: Path | None = None,
+        output_dir: Path | None = None,
+    ) -> None:
+        exit_code, _, stderr = self.run_cli(
+            input_dir=input_dir,
+            output_dir=output_dir,
+        )
+        self.assertEqual(exit_code, 2)
+        self.assertIn(expected_reason, stderr)
+
+    def create_second_source(self, root: Path) -> Path:
+        source_dir = root / "different-source-root"
+        result = stress.run_stress(FIXTURES_DIR)
+        artifacts = stress.write_artifacts(result, source_dir)
+        self.assertTrue(artifacts["verify"]["verified"])
+        return source_dir
+
+    def test_canonical_analyzer_cli_returns_zero(self) -> None:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS_DIR / "tasukeru_arl_hash_chain_analyzer.py"),
+                "--input-dir",
+                str(self.source_dir),
+                "--output-dir",
+                str(self.output_dir),
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("verified: True", completed.stdout)
+
+    def test_canonical_output_filename_set_is_exact(self) -> None:
+        self.run_canonical()
+        self.assertEqual(
+            {path.name for path in self.output_dir.iterdir()},
+            analyzer.EXPECTED_OUTPUT_FILES,
+        )
+
+    def test_result_schema_is_exact(self) -> None:
+        result, _, _ = self.run_canonical()
+        self.assertEqual(set(result), RESULT_FIELDS)
+        self.assertEqual(result["schema_version"], analyzer.RESULT_SCHEMA_VERSION)
+
+    def test_graph_schema_is_exact(self) -> None:
+        _, graph, _ = self.run_canonical()
+        self.assertEqual(set(graph), GRAPH_FIELDS)
+        self.assertEqual(graph["schema_version"], analyzer.GRAPH_SCHEMA_VERSION)
+
+    def test_verify_schema_is_exact(self) -> None:
+        _, _, verify = self.run_canonical()
+        self.assertEqual(set(verify), VERIFY_FIELDS)
+        self.assertEqual(verify["schema_version"], analyzer.VERIFY_SCHEMA_VERSION)
+
+    def test_all_generated_timestamps_are_deterministic(self) -> None:
+        result, graph, verify = self.run_canonical()
+        self.assertEqual(
+            {
+                result["generated_at_utc"],
+                graph["generated_at_utc"],
+                verify["generated_at_utc"],
+            },
+            {analyzer.DETERMINISTIC_GENERATED_AT_UTC},
+        )
+
+    def test_source_result_sha256_binding_is_verified(self) -> None:
+        result, _, verify = self.run_canonical()
+        expected = sha256_file(self.source_dir / analyzer.SOURCE_RESULT_FILENAME)
+        self.assertEqual(
+            result["source_documents"][analyzer.SOURCE_RESULT_FILENAME]["sha256"],
+            expected,
+        )
+        self.assertEqual(
+            verify["source_document_sha256"][analyzer.SOURCE_RESULT_FILENAME],
+            expected,
+        )
+
+    def test_source_report_sha256_binding_is_verified(self) -> None:
+        result, _, verify = self.run_canonical()
+        expected = sha256_file(self.source_dir / analyzer.SOURCE_REPORT_FILENAME)
+        self.assertEqual(
+            result["source_documents"][analyzer.SOURCE_REPORT_FILENAME]["sha256"],
+            expected,
+        )
+        self.assertEqual(
+            verify["source_document_sha256"][analyzer.SOURCE_REPORT_FILENAME],
+            expected,
+        )
+
+    def test_manifest_sha256_cross_document_binding_is_verified(self) -> None:
+        result, _, verify = self.run_canonical()
+        source_result = load_json(self.source_dir / analyzer.SOURCE_RESULT_FILENAME)
+        source_verify = load_json(self.source_dir / analyzer.SOURCE_VERIFY_FILENAME)
+        expected = source_result["manifest_sha256"]
+        self.assertEqual(expected, source_verify["manifest_sha256"])
+        self.assertEqual(result["source_manifest_sha256"], expected)
+        self.assertEqual(verify["source_manifest_sha256"], expected)
+
+    def test_t1_is_expected_canonical_validation(self) -> None:
+        result, _, _ = self.run_canonical()
+        case = result["cases"][0]
+        self.assertEqual(case["case_id"], "valid_chain")
+        self.assertEqual(case["classification"], "EXPECTED_CANONICAL_VALIDATION")
+        self.assertEqual(case["actual_outcome"], "CHAIN_VALID")
+        self.assertTrue(case["passed"])
+
+    def test_t2_through_t7_are_expected_tamper_detections(self) -> None:
+        result, _, _ = self.run_canonical()
+        for case in result["cases"][1:]:
+            with self.subTest(case_id=case["case_id"]):
+                self.assertEqual(
+                    case["classification"],
+                    "EXPECTED_TAMPER_DETECTION",
+                )
+                self.assertEqual(case["actual_outcome"], "TAMPER_DETECTED")
+                self.assertTrue(case["passed"])
+
+    def test_all_cases_preserve_canonical_order(self) -> None:
+        result, _, _ = self.run_canonical()
+        self.assertEqual(
+            [case["case_id"] for case in result["cases"]],
+            list(analyzer.CANONICAL_CASE_IDS),
+        )
+
+    def test_primary_and_additional_reason_order_is_preserved(self) -> None:
+        result, _, _ = self.run_canonical()
+        source = load_json(self.source_dir / analyzer.SOURCE_RESULT_FILENAME)
+        for normalized, original in zip(
+            result["cases"],
+            source["cases"],
+            strict=True,
+        ):
+            with self.subTest(case_id=normalized["case_id"]):
+                self.assertEqual(
+                    [reason["reason_code"] for reason in normalized["reasons"]],
+                    original["reason_codes"],
+                )
+                self.assertEqual(normalized["reasons"][0]["role"], "primary")
+                self.assertTrue(
+                    all(
+                        reason["role"] == "additional"
+                        for reason in normalized["reasons"][1:]
+                    )
+                )
+
+    def test_all_nineteen_integrity_issue_occurrences_are_preserved(self) -> None:
+        result, _, _ = self.run_canonical()
+        integrity_issues = [
+            issue
+            for case in result["cases"]
+            for issue in case["issues"]
+            if issue["is_integrity_issue"]
+        ]
+        self.assertEqual(len(integrity_issues), 19)
+
+    def test_all_source_issue_entries_are_preserved_in_order(self) -> None:
+        result, _, _ = self.run_canonical()
+        source = load_json(self.source_dir / analyzer.SOURCE_RESULT_FILENAME)
+        for normalized, original in zip(
+            result["cases"],
+            source["cases"],
+            strict=True,
+        ):
+            with self.subTest(case_id=normalized["case_id"]):
+                self.assertEqual(len(normalized["issues"]), len(original["issues"]))
+                self.assertEqual(
+                    [issue["issue_ordinal"] for issue in normalized["issues"]],
+                    list(range(1, len(original["issues"]) + 1)),
+                )
+
+    def test_each_issue_preserves_required_evidence(self) -> None:
+        result, _, _ = self.run_canonical()
+        source = load_json(self.source_dir / analyzer.SOURCE_RESULT_FILENAME)
+        for normalized_case, source_case in zip(
+            result["cases"],
+            source["cases"],
+            strict=True,
+        ):
+            for normalized, original in zip(
+                normalized_case["issues"],
+                source_case["issues"],
+                strict=True,
+            ):
+                self.assertEqual(set(normalized), ISSUE_FIELDS)
+                for field in (
+                    "line_number",
+                    "reason_code",
+                    "detail",
+                    "stored_value",
+                    "recomputed_value",
+                ):
+                    self.assertEqual(normalized[field], original[field])
+
+    def test_head_hash_concepts_remain_separate(self) -> None:
+        result, _, _ = self.run_canonical()
+        source = load_json(self.source_dir / analyzer.SOURCE_RESULT_FILENAME)
+        for normalized, original in zip(
+            result["cases"],
+            source["cases"],
+            strict=True,
+        ):
+            self.assertEqual(
+                normalized["expected_canonical_head_hash"],
+                analyzer.CANONICAL_HEAD_HASH,
+            )
+            self.assertEqual(
+                normalized["stored_head_hash"],
+                original["stored_head_hash"],
+            )
+            self.assertEqual(
+                normalized["recomputed_head_hash"],
+                original["recomputed_head_hash"],
+            )
+
+    def test_graph_node_ids_are_stable_across_roots(self) -> None:
+        _, graph_one, _ = self.run_canonical()
+        second_root = self.root / "second"
+        second_source = self.create_second_source(second_root)
+        second_output = second_root / "output"
+        exit_code, _, stderr = self.run_cli(
+            input_dir=second_source,
+            output_dir=second_output,
+        )
+        self.assertEqual(exit_code, 0, stderr)
+        graph_two = load_json(second_output / analyzer.GRAPH_FILENAME)
+        self.assertEqual(
+            [node["id"] for node in graph_one["nodes"]],
+            [node["id"] for node in graph_two["nodes"]],
+        )
+
+    def test_graph_edge_ids_are_stable_across_roots(self) -> None:
+        _, graph_one, _ = self.run_canonical()
+        second_root = self.root / "second"
+        second_source = self.create_second_source(second_root)
+        second_output = second_root / "output"
+        exit_code, _, stderr = self.run_cli(
+            input_dir=second_source,
+            output_dir=second_output,
+        )
+        self.assertEqual(exit_code, 0, stderr)
+        graph_two = load_json(second_output / analyzer.GRAPH_FILENAME)
+        self.assertEqual(
+            [edge["id"] for edge in graph_one["edges"]],
+            [edge["id"] for edge in graph_two["edges"]],
+        )
+
+    def test_graph_reason_edges_preserve_order_and_role(self) -> None:
+        result, graph, _ = self.run_canonical()
+        for case in result["cases"]:
+            case_node = analyzer.stable_id("hash_chain_case", case["case_id"])
+            edges = sorted(
+                (
+                    edge
+                    for edge in graph["edges"]
+                    if edge["source"] == case_node and edge["type"] == "HAS_REASON"
+                ),
+                key=lambda edge: edge["properties"]["order"],
+            )
+            self.assertEqual(
+                [edge["properties"]["order"] for edge in edges],
+                list(range(1, len(case["reasons"]) + 1)),
+            )
+            self.assertEqual(
+                [edge["properties"]["role"] for edge in edges],
+                [reason["role"] for reason in case["reasons"]],
+            )
+
+    def test_graph_issue_edges_preserve_ordinal_order(self) -> None:
+        result, graph, _ = self.run_canonical()
+        for case in result["cases"]:
+            case_node = analyzer.stable_id("hash_chain_case", case["case_id"])
+            edges = sorted(
+                (
+                    edge
+                    for edge in graph["edges"]
+                    if edge["source"] == case_node and edge["type"] == "HAS_ISSUE"
+                ),
+                key=lambda edge: edge["properties"]["issue_ordinal"],
+            )
+            expected = [
+                issue["issue_ordinal"]
+                for issue in case["issues"]
+                if issue["is_integrity_issue"]
+            ]
+            self.assertEqual(
+                [edge["properties"]["issue_ordinal"] for edge in edges],
+                expected,
+            )
+
+    def test_graph_does_not_contain_raw_fixture_rows(self) -> None:
+        _, _, _ = self.run_canonical()
+        graph_bytes = (self.output_dir / analyzer.GRAPH_FILENAME).read_bytes()
+        for fixture_name in sorted(
+            name for name in stress.PATCH_13_CASE_IDS if name != "valid_chain"
+        ):
+            fixture_path = FIXTURES_DIR / f"{fixture_name}.jsonl"
+            for line in fixture_path.read_bytes().splitlines():
+                self.assertNotIn(line, graph_bytes)
+        for line in (FIXTURES_DIR / "valid_chain.jsonl").read_bytes().splitlines():
+            self.assertNotIn(line, graph_bytes)
+
+    def test_separate_roots_produce_byte_identical_outputs(self) -> None:
+        self.run_canonical()
+        second_root = self.root / "determinism-copy"
+        second_source = self.create_second_source(second_root)
+        second_output = second_root / "output"
+        exit_code, _, stderr = self.run_cli(
+            input_dir=second_source,
+            output_dir=second_output,
+        )
+        self.assertEqual(exit_code, 0, stderr)
+        for filename in analyzer.EXPECTED_OUTPUT_FILES:
+            with self.subTest(filename=filename):
+                self.assertEqual(
+                    (self.output_dir / filename).read_bytes(),
+                    (second_output / filename).read_bytes(),
+                )
+
+    def test_missing_source_result_returns_two(self) -> None:
+        (self.source_dir / analyzer.SOURCE_RESULT_FILENAME).unlink()
+        self.assert_operational_failure("ARL_ANALYZER_SOURCE_FILE_MISSING")
+
+    def test_missing_source_report_returns_two(self) -> None:
+        (self.source_dir / analyzer.SOURCE_REPORT_FILENAME).unlink()
+        self.assert_operational_failure("ARL_ANALYZER_SOURCE_FILE_MISSING")
+
+    def test_missing_source_verify_returns_two(self) -> None:
+        (self.source_dir / analyzer.SOURCE_VERIFY_FILENAME).unlink()
+        self.assert_operational_failure("ARL_ANALYZER_SOURCE_FILE_MISSING")
+
+    def test_extra_source_file_returns_two(self) -> None:
+        (self.source_dir / "unexpected.txt").write_text("unexpected\n", encoding="utf-8")
+        self.assert_operational_failure("ARL_ANALYZER_UNEXPECTED_SOURCE_ENTRY")
+
+    def test_invalid_result_json_returns_two(self) -> None:
+        (self.source_dir / analyzer.SOURCE_RESULT_FILENAME).write_text(
+            "{invalid\n",
+            encoding="utf-8",
+        )
+        self.assert_operational_failure("ARL_ANALYZER_RESULT_JSON_INVALID")
+
+    def test_invalid_verify_json_returns_two(self) -> None:
+        (self.source_dir / analyzer.SOURCE_VERIFY_FILENAME).write_text(
+            "{invalid\n",
+            encoding="utf-8",
+        )
+        self.assert_operational_failure("ARL_ANALYZER_VERIFY_JSON_INVALID")
+
+    def test_unsupported_result_schema_returns_two(self) -> None:
+        self.mutate_result(
+            lambda result: result.__setitem__("schema_version", "unsupported"),
+            rebind=False,
+        )
+        self.assert_operational_failure("ARL_ANALYZER_RESULT_SCHEMA_UNSUPPORTED")
+
+    def test_unsupported_verify_schema_returns_two(self) -> None:
+        self.mutate_verify(
+            lambda verify: verify.__setitem__("schema_version", "unsupported")
+        )
+        self.assert_operational_failure("ARL_ANALYZER_VERIFY_SCHEMA_UNSUPPORTED")
+
+    def test_non_object_result_returns_two(self) -> None:
+        write_json(self.source_dir / analyzer.SOURCE_RESULT_FILENAME, [])
+        self.assert_operational_failure("ARL_ANALYZER_RESULT_JSON_INVALID")
+
+    def test_non_object_verify_returns_two(self) -> None:
+        write_json(self.source_dir / analyzer.SOURCE_VERIFY_FILENAME, [])
+        self.assert_operational_failure("ARL_ANALYZER_VERIFY_JSON_INVALID")
+
+    def test_non_empty_output_directory_returns_two(self) -> None:
+        self.output_dir.mkdir()
+        (self.output_dir / "stale.txt").write_text("stale\n", encoding="utf-8")
+        self.assert_operational_failure("ARL_ANALYZER_OUTPUT_DIRECTORY_NOT_EMPTY")
+
+    def test_source_verify_false_produces_exit_one_and_artifacts(self) -> None:
+        self.mutate_verify(lambda verify: verify.__setitem__("verified", False))
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["source_verify_verified"])
+
+    def test_source_result_false_produces_exit_one_and_artifacts(self) -> None:
+        self.mutate_result(lambda result: result.__setitem__("verified", False))
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["source_result_verified"])
+
+    def test_result_sha_mismatch_produces_exit_one(self) -> None:
+        self.mutate_result(
+            lambda result: result.__setitem__("mode", "changed"),
+            rebind=False,
+        )
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["source_result_hash_matches"])
+
+    def test_report_sha_mismatch_produces_exit_one(self) -> None:
+        report_path = self.source_dir / analyzer.SOURCE_REPORT_FILENAME
+        report_path.write_text(
+            report_path.read_text(encoding="utf-8") + "changed\n",
+            encoding="utf-8",
+        )
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["source_report_hash_matches"])
+
+    def test_manifest_sha_mismatch_produces_exit_one(self) -> None:
+        self.mutate_result(
+            lambda result: result.__setitem__("manifest_sha256", "0" * 64)
+        )
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["source_manifest_hash_bound"])
+
+    def test_wrong_canonical_case_order_produces_exit_one(self) -> None:
+        self.mutate_result(
+            lambda result: result["cases"].__setitem__(
+                slice(0, 2),
+                list(reversed(result["cases"][:2])),
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["canonical_case_order_valid"])
+
+    def test_missing_canonical_case_produces_exit_one(self) -> None:
+        self.mutate_result(lambda result: result["cases"].pop())
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["canonical_case_order_valid"])
+
+    def test_extra_case_produces_exit_one(self) -> None:
+        def add_extra(result: dict[str, Any]) -> None:
+            extra = json.loads(json.dumps(result["cases"][-1]))
+            extra["case_id"] = "unexpected_case"
+            result["cases"].append(extra)
+
+        self.mutate_result(add_extra)
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["canonical_case_order_valid"])
+
+    def test_wrong_tamper_outcome_produces_exit_one(self) -> None:
+        self.mutate_result(
+            lambda result: result["cases"][1].__setitem__(
+                "actual_outcome",
+                "CHAIN_VALID",
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["canonical_case_semantics_valid"])
+
+    def test_wrong_reason_order_produces_exit_one(self) -> None:
+        self.mutate_result(
+            lambda result: result["cases"][1].__setitem__(
+                "reason_codes",
+                list(reversed(result["cases"][1]["reason_codes"])),
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["reason_code_order_valid"])
+
+    def test_issue_count_mismatch_produces_exit_one(self) -> None:
+        self.mutate_result(lambda result: result["cases"][1]["issues"].pop())
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["source_issue_contract_valid"])
+
+    def test_rebound_issue_reason_mutation_produces_exit_one(self) -> None:
+        self.mutate_result(
+            lambda result: result["cases"][1]["issues"][0].__setitem__(
+                "reason_code",
+                "ARL_CHAIN_HASH_MISMATCH",
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertTrue(verify["checks"]["source_result_hash_matches"])
+        self.assertFalse(verify["checks"]["source_issue_contract_valid"])
+
+    def test_rebound_issue_order_mutation_produces_exit_one(self) -> None:
+        def swap_issues(result: dict[str, Any]) -> None:
+            issues = result["cases"][1]["issues"]
+            issues[0], issues[1] = issues[1], issues[0]
+
+        self.mutate_result(swap_issues)
+        verify = self.assert_semantic_failure()
+        self.assertTrue(verify["checks"]["source_result_hash_matches"])
+        self.assertFalse(verify["checks"]["source_issue_contract_valid"])
+
+    def test_rebound_issue_line_number_mutation_produces_exit_one(self) -> None:
+        self.mutate_result(
+            lambda result: result["cases"][1]["issues"][0].__setitem__(
+                "line_number",
+                3,
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertTrue(verify["checks"]["source_result_hash_matches"])
+        self.assertFalse(verify["checks"]["source_issue_contract_valid"])
+
+    def test_rebound_issue_detail_mutation_produces_exit_one(self) -> None:
+        self.mutate_result(
+            lambda result: result["cases"][1]["issues"][0].__setitem__(
+                "detail",
+                "Changed canonical detail.",
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertTrue(verify["checks"]["source_result_hash_matches"])
+        self.assertFalse(verify["checks"]["source_issue_contract_valid"])
+
+    def test_rebound_issue_stored_value_mutation_produces_exit_one(self) -> None:
+        self.mutate_result(
+            lambda result: result["cases"][1]["issues"][0].__setitem__(
+                "stored_value",
+                "0" * 64,
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertTrue(verify["checks"]["source_result_hash_matches"])
+        self.assertFalse(verify["checks"]["source_issue_contract_valid"])
+
+    def test_rebound_issue_recomputed_value_mutation_produces_exit_one(self) -> None:
+        self.mutate_result(
+            lambda result: result["cases"][1]["issues"][0].__setitem__(
+                "recomputed_value",
+                "1" * 64,
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertTrue(verify["checks"]["source_result_hash_matches"])
+        self.assertFalse(verify["checks"]["source_issue_contract_valid"])
+
+    def test_rebound_valid_chain_stored_head_mutation_produces_exit_one(self) -> None:
+        self.mutate_result(
+            lambda result: result["cases"][0].__setitem__(
+                "stored_head_hash",
+                "2" * 64,
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertTrue(verify["checks"]["source_result_hash_matches"])
+        self.assertFalse(verify["checks"]["head_hash_evidence_valid"])
+
+    def test_rebound_valid_chain_recomputed_head_mutation_produces_exit_one(
+        self,
+    ) -> None:
+        self.mutate_result(
+            lambda result: result["cases"][0].__setitem__(
+                "recomputed_head_hash",
+                "3" * 64,
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertTrue(verify["checks"]["source_result_hash_matches"])
+        self.assertFalse(verify["checks"]["head_hash_evidence_valid"])
+
+    def test_rebound_tamper_case_stored_head_mutation_produces_exit_one(
+        self,
+    ) -> None:
+        self.mutate_result(
+            lambda result: result["cases"][4].__setitem__(
+                "stored_head_hash",
+                "4" * 64,
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertTrue(verify["checks"]["source_result_hash_matches"])
+        self.assertFalse(verify["checks"]["head_hash_evidence_valid"])
+
+    def test_rebound_tamper_case_recomputed_head_mutation_produces_exit_one(
+        self,
+    ) -> None:
+        self.mutate_result(
+            lambda result: result["cases"][4].__setitem__(
+                "recomputed_head_hash",
+                "5" * 64,
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertTrue(verify["checks"]["source_result_hash_matches"])
+        self.assertFalse(verify["checks"]["head_hash_evidence_valid"])
+
+    def test_hmac_claim_is_rejected(self) -> None:
+        self.mutate_verify(lambda verify: verify.__setitem__("hmac_enabled", True))
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["source_hmac_disabled"])
+
+    def test_authenticity_claim_is_rejected(self) -> None:
+        self.mutate_verify(
+            lambda verify: verify.__setitem__("authenticity_claimed", True)
+        )
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["source_authenticity_not_claimed"])
+
+    def test_safety_boundary_mutation_produces_exit_one(self) -> None:
+        self.mutate_result(
+            lambda result: result["safety_boundary"].__setitem__(
+                "automatic_repair",
+                True,
+            )
+        )
+        verify = self.assert_semantic_failure()
+        self.assertFalse(verify["checks"]["source_result_safety_boundary_valid"])
+
+    def test_absolute_temporary_paths_are_absent_from_artifacts(self) -> None:
+        self.run_canonical()
+        root_text = str(self.root)
+        for filename in analyzer.EXPECTED_OUTPUT_FILES:
+            with self.subTest(filename=filename):
+                self.assertNotIn(
+                    root_text,
+                    (self.output_dir / filename).read_text(encoding="utf-8"),
+                )
+
+    def test_safety_boundary_contains_no_automatic_or_external_authority(self) -> None:
+        result, graph, verify = self.run_canonical()
+        for boundary in (
+            result["safety_boundary"],
+            graph["safety_boundary"],
+            verify["safety_boundary"],
+        ):
+            self.assertTrue(boundary["advisory_only"])
+            self.assertTrue(boundary["human_review_required"])
+            for key, value in boundary.items():
+                if key not in {"advisory_only", "human_review_required"}:
+                    self.assertFalse(value, key)
+
+    def test_existing_patch_13_source_artifacts_are_not_modified(self) -> None:
+        before = {
+            path.name: sha256_file(path)
+            for path in self.source_dir.iterdir()
+            if path.is_file()
+        }
+        self.run_canonical()
+        after = {
+            path.name: sha256_file(path)
+            for path in self.source_dir.iterdir()
+            if path.is_file()
+        }
+        self.assertEqual(before, after)
+
+    def test_existing_patch_4_analyzer_is_not_imported_or_modified(self) -> None:
+        patch4_path = SCRIPTS_DIR / "tasukeru_arl_analyzer.py"
+        before = sha256_file(patch4_path)
+        self.run_canonical()
+        after = sha256_file(patch4_path)
+        source_text = Path(analyzer.__file__).read_text(encoding="utf-8")
+        self.assertEqual(before, after)
+        self.assertNotIn("import tasukeru_arl_analyzer", source_text)
+        self.assertNotIn("from tasukeru_arl_analyzer", source_text)
+
+    def test_missing_input_directory_returns_two(self) -> None:
+        self.assert_operational_failure(
+            "ARL_ANALYZER_INPUT_DIRECTORY_INVALID",
+            input_dir=self.root / "missing",
+        )
+
+    def test_invalid_result_utf8_returns_two(self) -> None:
+        (self.source_dir / analyzer.SOURCE_RESULT_FILENAME).write_bytes(b"\xff")
+        self.assert_operational_failure("ARL_ANALYZER_RESULT_UTF8_INVALID")
+
+    def test_invalid_report_utf8_returns_two(self) -> None:
+        (self.source_dir / analyzer.SOURCE_REPORT_FILENAME).write_bytes(b"\xff")
+        self.assert_operational_failure("ARL_ANALYZER_REPORT_UTF8_INVALID")
+
+    def test_invalid_verify_utf8_returns_two(self) -> None:
+        (self.source_dir / analyzer.SOURCE_VERIFY_FILENAME).write_bytes(b"\xff")
+        self.assert_operational_failure("ARL_ANALYZER_VERIFY_UTF8_INVALID")
+
+    def test_extra_source_directory_returns_two(self) -> None:
+        (self.source_dir / "unexpected-directory").mkdir()
+        self.assert_operational_failure("ARL_ANALYZER_UNEXPECTED_SOURCE_ENTRY")
+
+    def test_input_output_overlap_returns_two(self) -> None:
+        self.assert_operational_failure(
+            "ARL_ANALYZER_INPUT_OUTPUT_OVERLAP",
+            output_dir=self.source_dir / "nested-output",
+        )
+
+    def test_existing_output_file_path_returns_two(self) -> None:
+        self.output_dir.write_text("not a directory\n", encoding="utf-8")
+        self.assert_operational_failure("ARL_ANALYZER_OUTPUT_DIRECTORY_INVALID")
+
+    def test_invalid_cli_usage_returns_two(self) -> None:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS_DIR / "tasukeru_arl_hash_chain_analyzer.py"),
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("required", completed.stderr)
+
+    def test_output_verify_hashes_bind_three_outputs(self) -> None:
+        _, _, verify = self.run_canonical()
+        self.assertEqual(
+            verify["result_sha256"],
+            sha256_file(self.output_dir / analyzer.RESULT_FILENAME),
+        )
+        self.assertEqual(
+            verify["graph_sha256"],
+            sha256_file(self.output_dir / analyzer.GRAPH_FILENAME),
+        )
+        self.assertEqual(
+            verify["report_sha256"],
+            sha256_file(self.output_dir / analyzer.REPORT_FILENAME),
+        )
+
+    def test_graph_contains_all_minimum_node_types(self) -> None:
+        _, graph, _ = self.run_canonical()
+        self.assertTrue(
+            {
+                "HashChainArtifactSet",
+                "SourceDocument",
+                "HashChainCase",
+                "ExpectedOutcome",
+                "ObservedOutcome",
+                "ReasonCode",
+                "IntegrityIssue",
+                "VerifyReport",
+            }.issubset({node["type"] for node in graph["nodes"]})
+        )
+
+    def test_graph_contains_all_minimum_edge_types(self) -> None:
+        _, graph, _ = self.run_canonical()
+        self.assertTrue(
+            {
+                "HAS_SOURCE",
+                "HAS_CASE",
+                "EXPECTED_OUTCOME",
+                "OBSERVED_OUTCOME",
+                "HAS_REASON",
+                "HAS_ISSUE",
+                "VERIFIES",
+            }.issubset({edge["type"] for edge in graph["edges"]})
+        )
+
+    def test_graph_hash_matches_canonical_graph_content(self) -> None:
+        _, graph, _ = self.run_canonical()
+        expected = analyzer.canonical_hash(
+            {
+                "schema_version": graph["schema_version"],
+                "logical_root": graph["logical_root"],
+                "nodes": graph["nodes"],
+                "edges": graph["edges"],
+            }
+        )
+        self.assertEqual(graph["graph_hash"], expected)
+
+    def test_report_contains_all_required_sections(self) -> None:
+        self.run_canonical()
+        report = (self.output_dir / analyzer.REPORT_FILENAME).read_text(
+            encoding="utf-8"
+        )
+        positions = [report.index(section) for section in REPORT_SECTIONS]
+        self.assertEqual(positions, sorted(positions))
+
+    def test_report_contains_all_required_limitations(self) -> None:
+        self.run_canonical()
+        report = (self.output_dir / analyzer.REPORT_FILENAME).read_text(
+            encoding="utf-8"
+        )
+        for statement in (
+            "HMAC is not enabled.",
+            "Authenticity is not claimed.",
+            "Hash consistency is not an external identity proof.",
+            "This artifact is advisory-only.",
+            "Final review remains human-controlled.",
+        ):
+            self.assertIn(statement, report)
+
+    def test_source_paths_are_logical_only(self) -> None:
+        result, graph, _ = self.run_canonical()
+        self.assertEqual(
+            result["source_contract"]["logical_path"],
+            analyzer.LOGICAL_SOURCE_ROOT,
+        )
+        for document in result["source_documents"].values():
+            self.assertTrue(
+                document["logical_path"].startswith(
+                    f"{analyzer.LOGICAL_SOURCE_ROOT}/"
+                )
+            )
+        root = next(
+            node
+            for node in graph["nodes"]
+            if node["type"] == "HashChainArtifactSet"
+        )
+        self.assertEqual(
+            root["properties"]["source_path"],
+            analyzer.LOGICAL_SOURCE_ROOT,
+        )
+
+    def test_graph_has_exactly_seven_case_nodes(self) -> None:
+        _, graph, _ = self.run_canonical()
+        cases = [node for node in graph["nodes"] if node["type"] == "HashChainCase"]
+        self.assertEqual(len(cases), 7)
+        self.assertEqual(graph["counts"]["cases"], 7)
+
+    def test_graph_has_exactly_nineteen_integrity_issue_nodes(self) -> None:
+        _, graph, _ = self.run_canonical()
+        issues = [
+            node for node in graph["nodes"] if node["type"] == "IntegrityIssue"
+        ]
+        self.assertEqual(len(issues), 19)
+        self.assertEqual(graph["counts"]["integrity_issues"], 19)
+
+    def test_graph_nodes_and_edges_are_sorted_by_id(self) -> None:
+        _, graph, _ = self.run_canonical()
+        self.assertEqual(
+            [node["id"] for node in graph["nodes"]],
+            sorted(node["id"] for node in graph["nodes"]),
+        )
+        self.assertEqual(
+            [edge["id"] for edge in graph["edges"]],
+            sorted(edge["id"] for edge in graph["edges"]),
+        )
+
+    def test_canonical_aggregate_counts_are_exact(self) -> None:
+        result, graph, verify = self.run_canonical()
+        expected = dict(analyzer.CANONICAL_COUNTS)
+        self.assertEqual(result["counts"], expected)
+        self.assertEqual(verify["counts"], expected)
+        self.assertEqual(graph["counts"]["cases"], expected["total_cases"])
+        self.assertEqual(
+            graph["counts"]["integrity_issues"],
+            expected["total_integrity_errors"],
+        )
+
+    def test_canonical_result_and_verify_checks_are_all_true(self) -> None:
+        result, _, verify = self.run_canonical()
+        self.assertTrue(result["verified"])
+        self.assertTrue(verify["verified"])
+        self.assertTrue(all(result["checks"].values()))
+        self.assertTrue(all(verify["checks"].values()))
+
+    def test_output_existence_checks_are_all_true(self) -> None:
+        _, _, verify = self.run_canonical()
+        self.assertTrue(all(verify["output_existence_checks"].values()))
+        self.assertTrue(verify["output_filename_set_exact"])
+
+    def test_json_and_markdown_outputs_use_lf_and_one_final_newline(self) -> None:
+        self.run_canonical()
+        for filename in analyzer.EXPECTED_OUTPUT_FILES:
+            with self.subTest(filename=filename):
+                data = (self.output_dir / filename).read_bytes()
+                self.assertNotIn(b"\r\n", data)
+                self.assertTrue(data.endswith(b"\n"))
+                self.assertFalse(data.endswith(b"\n\n"))
+
+    def test_generated_artifacts_contain_no_temporary_root_name(self) -> None:
+        self.run_canonical()
+        temporary_name = self.root.name
+        for filename in analyzer.EXPECTED_OUTPUT_FILES:
+            self.assertNotIn(
+                temporary_name,
+                (self.output_dir / filename).read_text(encoding="utf-8"),
+            )
+
+    def test_source_directory_contains_exactly_three_files(self) -> None:
+        self.run_canonical()
+        self.assertEqual(
+            {path.name for path in self.source_dir.iterdir()},
+            analyzer.EXPECTED_SOURCE_FILES,
+        )
+
+    def test_verify_explicitly_disables_hmac_and_authenticity_claim(self) -> None:
+        _, _, verify = self.run_canonical()
+        self.assertIs(verify["hmac_enabled"], False)
+        self.assertIs(verify["authenticity_claimed"], False)
+
+    def test_result_mode_is_advisory_only(self) -> None:
+        result, graph, _ = self.run_canonical()
+        self.assertEqual(
+            result["mode"],
+            "advisory_only_deterministic_hash_chain_analyzer",
+        )
+        self.assertEqual(
+            graph["mode"],
+            "advisory_only_deterministic_hash_chain_graph",
+        )
+
+    def test_graph_uses_dedicated_patch_13_schema(self) -> None:
+        _, graph, _ = self.run_canonical()
+        self.assertEqual(graph["schema_version"], analyzer.GRAPH_SCHEMA_VERSION)
+        self.assertNotEqual(
+            graph["schema_version"],
+            "tasukeru-arl-graph-v0.1",
+        )
+
+    def test_reason_nodes_do_not_collapse_issue_nodes(self) -> None:
+        _, graph, _ = self.run_canonical()
+        reason_nodes = [node for node in graph["nodes"] if node["type"] == "ReasonCode"]
+        issue_nodes = [
+            node for node in graph["nodes"] if node["type"] == "IntegrityIssue"
+        ]
+        self.assertEqual(
+            len(reason_nodes),
+            len(
+                {
+                    reason
+                    for contract in analyzer.CANONICAL_CASE_CONTRACTS
+                    for reason in contract["reason_codes"]
+                }
+            ),
+        )
+        self.assertEqual(len(issue_nodes), 19)
+
+    def test_issue_nodes_preserve_stored_and_recomputed_values(self) -> None:
+        result, graph, _ = self.run_canonical()
+        case_by_id = {case["case_id"]: case for case in result["cases"]}
+        for node in graph["nodes"]:
+            if node["type"] != "IntegrityIssue":
+                continue
+            case_id = node["label"].split(" issue ", 1)[0]
+            ordinal = node["properties"]["issue_ordinal"]
+            issue = case_by_id[case_id]["issues"][ordinal - 1]
+            self.assertEqual(
+                node["properties"]["stored_value"],
+                issue["stored_value"],
+            )
+            self.assertEqual(
+                node["properties"]["recomputed_value"],
+                issue["recomputed_value"],
+            )
+
+    def test_semantic_failure_does_not_normalize_to_verified_true(self) -> None:
+        self.mutate_result(
+            lambda result: result["counts"].__setitem__("failed_cases", 1)
+        )
+        verify = self.assert_semantic_failure()
+        result = load_json(self.output_dir / analyzer.RESULT_FILENAME)
+        self.assertFalse(result["verified"])
+        self.assertFalse(verify["verified"])
+
+    def test_output_directory_is_not_created_on_schema_failure(self) -> None:
+        self.mutate_verify(
+            lambda verify: verify.__setitem__("schema_version", "unsupported")
+        )
+        self.assert_operational_failure("ARL_ANALYZER_VERIFY_SCHEMA_UNSUPPORTED")
+        self.assertFalse(self.output_dir.exists())
+
+    def test_stderr_operational_error_is_path_free(self) -> None:
+        missing = self.root / "physical" / "private" / "missing"
+        exit_code, _, stderr = self.run_cli(input_dir=missing)
+        self.assertEqual(exit_code, 2)
+        self.assertNotIn(str(missing), stderr)
+        self.assertIn("ARL_ANALYZER_INPUT_DIRECTORY_INVALID", stderr)
+
+    def test_source_verify_schema_versions_are_recorded(self) -> None:
+        _, _, verify = self.run_canonical()
+        self.assertEqual(
+            verify["source_schema_versions"],
+            {
+                "result": analyzer.SOURCE_RESULT_SCHEMA_VERSION,
+                "verify": analyzer.SOURCE_VERIFY_SCHEMA_VERSION,
+            },
+        )
+
+    def test_source_document_paths_and_hashes_have_fixed_names(self) -> None:
+        result, _, _ = self.run_canonical()
+        self.assertEqual(
+            set(result["source_documents"]),
+            analyzer.EXPECTED_SOURCE_FILES,
+        )
+        for filename, document in result["source_documents"].items():
+            self.assertEqual(
+                document["logical_path"],
+                f"{analyzer.LOGICAL_SOURCE_ROOT}/{filename}",
+            )
+            self.assertRegex(document["sha256"], r"^[0-9a-f]{64}$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the deterministic Patch 13 Phase 4 ARL hash-chain analyzer and its repository CI integration.

The analyzer consumes the existing Patch 13 stress evidence:

- stress result JSON
- stress verification JSON
- Markdown report

It validates the evidence set fail-closed and generates deterministic analyzer outputs without modifying the source evidence.

## Analyzer behavior

- Verifies the source result and report SHA-256 values recorded by the verification evidence.
- Confirms cross-document fixture-manifest SHA-256 consistency.
- Validates the exact canonical outcomes for cases T1–T7.
- Preserves the exact order and content of all source integrity issues.
- Verifies stored, recomputed, and canonical chain-head hashes against immutable expected contracts.
- Distinguishes expected tamper detection from analyzer failure.
- Does not claim HMAC verification, signatures, or authenticity.

Expected semantic summary:

- 7 total cases
- 1 canonical valid-chain case
- 6 expected tamper-detection cases
- 27 total ARL rows
- 19 integrity-error occurrences
- 20 total source issues, including the informational valid-chain issue

## Generated artifacts

The workflow generates and uploads:

- `tasukeru_arl_hash_chain_analyzer_result.json`
- `tasukeru_arl_hash_chain_graph.json`
- `tasukeru_arl_hash_chain_analyzer_report.md`
- `tasukeru_arl_hash_chain_analyzer_verify.json`

Artifact name:

- `tasukeru-arl-hash-chain-analyzer-results`

Generated outputs are excluded from the repository through `.gitignore`.

## Exit contract

- `0`: analyzer verification succeeded
- `1`: analysis completed, but an integrity, semantic, or output requirement was not met
- `2`: argument, schema, read/write, configuration, or unexpected operational error

## Verification

Local verification completed successfully:

- focused analyzer tests: 96 passed
- Patch 13 tests: 39 passed
- existing Patch 4 tests: 11 passed
- existing Patch 3 tests: 8 passed
- full stress test discovery: 154 passed
- analyzer CLI exit: 0
- analyzer verification: true
- deterministic output checks passed
- no failures, errors, or skipped tests

The tests include adversarial cases that alter issue ordering, issue contents, and chain-head values while preserving superficially plausible structure.

## Changed files

- `.github/workflows/tasukeru-analysis.yml`
- `.gitignore`
- `scripts/tasukeru_arl_hash_chain_analyzer.py`
- `tests/stress/test_tasukeru_arl_hash_chain_analyzer.py`

The workflow change is limited to deterministic analyzer artifact generation and upload.

## Safety boundary

This implementation is:

- deterministic
- local
- advisory-only
- human-review-gated
- fail-closed

It does not add:

- external AI calls
- external service calls
- secrets or API keys
- HMAC keys or signatures
- authenticity claims
- automatic repair
- automatic commit or push
- automatic pull-request creation
- automatic merge
- deployment
- repository source modification at runtime
- new dependencies

Existing Patch 3 and Patch 4 analyzers and their output contracts remain unchanged.

## Scope boundary

This pull request covers Patch 13 Phase 4 only.

The following remain out of scope:

- runtime ARL integration
- HMAC or digital-signature verification
- key management
- external attestation
- automatic remediation
- deep dynamic analysis